### PR TITLE
[feat] 회원가입 폼 구현 및 Keycloak 인증 통합

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "^1.13.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "keycloak-js": "^26.2.3",
         "lucide-react": "^0.563.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -4323,6 +4324,15 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/keycloak-js": {
+      "version": "26.2.3",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.3.tgz",
+      "integrity": "sha512-widjzw/9T6bHRgEp6H/Se3NCCarU7u5CwFKBcwtu7xfA1IfdZb+7Q7/KGusAnBo34Vtls8Oz9vzSqkQvQ7+b4Q==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "test"
+      ]
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "axios": "^1.13.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "keycloak-js": "^26.2.3",
     "lucide-react": "^0.563.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/public/silent-check-sso.html
+++ b/public/silent-check-sso.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/src/common/api/apiInstacne.js
+++ b/src/common/api/apiInstacne.js
@@ -1,9 +1,39 @@
 import axios from "axios";
+import keycloak from "@/common/auth/keycloak";
 
 export const axiosInstance = axios.create({
-    baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8080/api',
+    baseURL: import.meta.env.VITE_API_URL || "http://localhost:8080/api",
     timeout: 5000,
     headers: {
-        'Content-Type': 'application/json'
-    }
+        "Content-Type": "application/json",
+    },
 });
+
+// 요청 인터셉터: 모든 API 요청에 Bearer 토큰 자동 주입
+axiosInstance.interceptors.request.use(
+    async (config) => {
+        if (keycloak.authenticated) {
+            try {
+                await keycloak.updateToken(70);
+                config.headers.Authorization = `Bearer ${keycloak.token}`;
+            } catch (error) {
+                console.error("Failed to refresh token", error);
+                keycloak.clearToken();
+            }
+        }
+        return config;
+    },
+    (error) => Promise.reject(error)
+);
+
+// 응답 인터셉터: 401 발생 시 로그인 페이지로 유도
+axiosInstance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+        if (error.response?.status === 401) {
+            console.warn("세션이 만료되었습니다. 다시 로그인해주세요.");
+            keycloak.login();
+        }
+        return Promise.reject(error);
+    }
+);

--- a/src/common/auth/KeycloakProvider.jsx
+++ b/src/common/auth/KeycloakProvider.jsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import keycloak from "./keycloak";
+
+const KeycloakContext = createContext(null);
+
+export function KeycloakProvider({ children }) {
+    const [authenticated, setAuthenticated] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        keycloak
+            .init({
+                onLoad: "check-sso",
+                silentCheckSsoRedirectUri: window.location.origin + "/silent-check-sso.html",
+            })
+            .then((auth) => {
+                setAuthenticated(auth);
+                setLoading(false);
+
+                keycloak.onTokenExpired = () => {
+                    keycloak.updateToken(70).then((refreshed) => {
+                        if (refreshed) console.log("Token refreshed");
+                    });
+                };
+            })
+            .catch((err) => {
+                console.error("Keycloak initialization failed", err);
+                setLoading(false);
+            });
+    }, []);
+
+    const value = {
+        keycloak,
+        authenticated,
+        loading,
+        login: (options) => keycloak.login(options),
+        logout: () => keycloak.logout({ redirectUri: window.location.origin + "/" }),
+    };
+
+    if (loading) return <div className="grid min-h-screen place-items-center text-sm text-zinc-500">인증 확인 중...</div>;
+
+    return (
+        <KeycloakContext.Provider value={value}>
+            {children}
+        </KeycloakContext.Provider>
+    );
+}
+
+export function useKeycloak() {
+    return useContext(KeycloakContext);
+}

--- a/src/common/auth/keycloak.js
+++ b/src/common/auth/keycloak.js
@@ -1,0 +1,9 @@
+import Keycloak from "keycloak-js";
+
+const keycloak = new Keycloak({
+    url: import.meta.env.VITE_KEYCLOAK_URL,
+    realm: import.meta.env.VITE_KEYCLOAK_REALM,
+    clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID,
+});
+
+export default keycloak;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -17,9 +17,9 @@ const menus = [
 ];
 
 export default function Header({
-    isLoggedIn = true,
-    hasNotifications = 3,
-    hasMessages = 2,
+    isLoggedIn = false,
+    hasNotifications = 0,
+    hasMessages = 0,
 }) {
     const [isScrolled, setIsScrolled] = useState(false);
     const [mobileOpen, setMobileOpen] = useState(false);
@@ -91,23 +91,24 @@ export default function Header({
                             {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
                         </Button>
 
-                        <Button
-                            asChild
-                            variant="outline"
-                            className="h-9 rounded-full border-zinc-300 bg-white/80 px-4 text-sm font-semibold text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900/80 dark:text-zinc-100 dark:hover:bg-zinc-800"
-                        >
-                            <Link to="/cart">장바구니</Link>
-                        </Button>
-                        <Button
-                            asChild
-                            variant="ghost"
-                            className="h-9 rounded-full px-4 text-sm font-semibold text-zinc-700 hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-800"
-                        >
-                            <Link to="/my">마이페이지</Link>
-                        </Button>
-
                         {isLoggedIn ? (
-                            <UserNavigation hasNotifications={hasNotifications} hasMessages={hasMessages} />
+                            <>
+                                <Button
+                                    asChild
+                                    variant="outline"
+                                    className="h-9 rounded-full border-zinc-300 bg-white/80 px-4 text-sm font-semibold text-zinc-700 hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900/80 dark:text-zinc-100 dark:hover:bg-zinc-800"
+                                >
+                                    <Link to="/cart">장바구니</Link>
+                                </Button>
+                                <Button
+                                    asChild
+                                    variant="ghost"
+                                    className="h-9 rounded-full px-4 text-sm font-semibold text-zinc-700 hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-800"
+                                >
+                                    <Link to="/my">마이페이지</Link>
+                                </Button>
+                                <UserNavigation hasNotifications={hasNotifications} hasMessages={hasMessages} />
+                            </>
                         ) : (
                             <AuthButtons />
                         )}
@@ -156,18 +157,19 @@ export default function Header({
                             >
                                 {isDark ? "라이트 모드" : "다크 모드"}
                             </Button>
-                            <Button
-                                asChild
-                                size="sm"
-                                className="rounded-full bg-zinc-900 px-4 text-white hover:bg-zinc-700 dark:bg-cyan-400/20 dark:text-cyan-100 dark:hover:bg-cyan-400/30"
-                            >
-                                <Link to="/cart" onClick={() => setMobileOpen(false)}>
-                                    장바구니
-                                </Link>
-                            </Button>
-
                             {isLoggedIn ? (
-                                <UserNavigation hasNotifications={hasNotifications} hasMessages={hasMessages} />
+                                <>
+                                    <Button
+                                        asChild
+                                        size="sm"
+                                        className="rounded-full bg-zinc-900 px-4 text-white hover:bg-zinc-700 dark:bg-cyan-400/20 dark:text-cyan-100 dark:hover:bg-cyan-400/30"
+                                    >
+                                        <Link to="/cart" onClick={() => setMobileOpen(false)}>
+                                            장바구니
+                                        </Link>
+                                    </Button>
+                                    <UserNavigation hasNotifications={hasNotifications} hasMessages={hasMessages} />
+                                </>
                             ) : (
                                 <AuthButtons />
                             )}

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -1,12 +1,15 @@
 import { Outlet } from "react-router";
 import Header from "@/components/layout/Header.jsx";
+import { useKeycloak } from "@/common/auth/KeycloakProvider.jsx";
 
 function MainLayout() {
+    const { authenticated } = useKeycloak();
+
     return (
         <div className="app-shell relative min-h-screen">
             <div className="app-shell-glow pointer-events-none absolute inset-0" />
 
-            <Header />
+            <Header isLoggedIn={authenticated} />
             <main className="relative mx-auto max-w-[1200px] px-4 pb-12 pt-24 sm:px-6 md:pb-16 md:pt-28">
                 <Outlet />
             </main>

--- a/src/components/user/UserNavigation.jsx
+++ b/src/components/user/UserNavigation.jsx
@@ -1,14 +1,17 @@
 import { Link } from "react-router";
 import { Button } from "@/components/ui/button";
 import { BarChart3Icon, BellIcon, LogOutIcon, MessageCircleIcon, SettingsIcon, UserIcon } from "lucide-react";
+import { useKeycloak } from "@/common/auth/KeycloakProvider";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "../ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 
 export function UserNavigation({
-                                   hasNotifications,
-                                   hasMessages,
-                               }) {
+    hasNotifications,
+    hasMessages,
+}) {
+    const { logout } = useKeycloak();
+
     return (
         <div className="flex items-center gap-2">
             <Button variant="ghost" size="icon" asChild className="relative">
@@ -66,11 +69,12 @@ export function UserNavigation({
                             </Link>
                         </DropdownMenuItem>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem asChild className="cursor-pointer">
-                            <Link to="/my/logout">
-                                <LogOutIcon className="size-4 mr-2" />
-                                Logout
-                            </Link>
+                        <DropdownMenuItem
+                            className="cursor-pointer"
+                            onClick={logout}
+                        >
+                            <LogOutIcon className="size-4 mr-2" />
+                            Logout
                         </DropdownMenuItem>
                     </DropdownMenuGroup>
                 </DropdownMenuContent>

--- a/src/domains/client/auth/page/JoinPage.jsx
+++ b/src/domains/client/auth/page/JoinPage.jsx
@@ -1,24 +1,580 @@
-import { Link } from "react-router";
+import { useState, useRef, useCallback } from "react";
+import { Link, useNavigate } from "react-router";
+import { z } from "zod";
+import { Eye, EyeOff, CheckCircle2, XCircle } from "lucide-react";
 
+import { axiosInstance } from "@/common/api/apiInstacne";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+const joinSchema = z
+    .object({
+        nickname: z
+            .string()
+            .min(2, "닉네임은 최소 2자 이상이어야 합니다.")
+            .max(50, "닉네임은 50자 이하여야 합니다."),
+        email: z.string().email("올바른 이메일 형식이 아닙니다."),
+        password: z
+            .string()
+            .min(8, "비밀번호는 최소 8자 이상이어야 합니다.")
+            .regex(/[a-zA-Z]/, "영문자가 포함되어야 합니다.")
+            .regex(/[0-9]/, "숫자가 포함되어야 합니다."),
+        confirmPassword: z.string(),
+    })
+    .refine((data) => data.password === data.confirmPassword, {
+        message: "비밀번호가 일치하지 않습니다.",
+        path: ["confirmPassword"],
+    });
+
+function FieldError({ message, id }) {
+    if (!message) return null;
+    return (
+        <p id={id} className="mt-1 text-xs text-red-500 dark:text-red-400" role="alert">
+            {message}
+        </p>
+    );
+}
+
+// 'idle' | 'checking' | 'available' | 'unavailable'
+const IDLE = "idle";
+const CHECKING = "checking";
+const AVAILABLE = "available";
+const UNAVAILABLE = "unavailable";
+
+function CheckBadge({ status }) {
+    if (status === AVAILABLE)
+        return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+    if (status === UNAVAILABLE)
+        return <XCircle className="h-4 w-4 text-red-500" />;
+    return null;
+}
 
 function JoinPage() {
+    const navigate = useNavigate();
+    const [formData, setFormData] = useState({
+        nickname: "",
+        email: "",
+        password: "",
+        confirmPassword: "",
+    });
+    const [fieldErrors, setFieldErrors] = useState({});
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [serverFeedback, setServerFeedback] = useState(null);
+
+    const [emailCheck, setEmailCheck] = useState({ status: IDLE, checkedValue: "" });
+    const [nicknameCheck, setNicknameCheck] = useState({ status: IDLE, checkedValue: "" });
+
+    // 이메일 인증 상태
+    const [emailVerif, setEmailVerif] = useState({
+        isSending: false,
+        sent: false,
+        code: "",
+        isVerifying: false,
+        verified: false,
+        error: null,
+    });
+    const [countdown, setCountdown] = useState(0);
+    const countdownRef = useRef(null);
+
+    const RESEND_COOLDOWN = 300; // 분
+
+    const formatCountdown = (sec) => {
+        const m = Math.floor(sec / 60).toString().padStart(2, "0");
+        const s = (sec % 60).toString().padStart(2, "0");
+        return `${m}:${s}`;
+    };
+
+    const startCountdown = useCallback(() => {
+        if (countdownRef.current) clearInterval(countdownRef.current);
+        setCountdown(RESEND_COOLDOWN);
+        countdownRef.current = setInterval(() => {
+            setCountdown((prev) => {
+                if (prev <= 1) {
+                    clearInterval(countdownRef.current);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+    }, []);
+
+    const stopCountdown = useCallback(() => {
+        if (countdownRef.current) clearInterval(countdownRef.current);
+        setCountdown(0);
+    }, []);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+        if (fieldErrors[name]) {
+            setFieldErrors((prev) => ({ ...prev, [name]: undefined }));
+        }
+        if (name === "email") {
+            setEmailCheck({ status: IDLE, checkedValue: "" });
+            setEmailVerif({ isSending: false, sent: false, code: "", isVerifying: false, verified: false, error: null });
+        }
+        if (name === "nickname") setNicknameCheck({ status: IDLE, checkedValue: "" });
+    };
+
+    const handleCheckEmail = async () => {
+        const emailResult = z.string().email().safeParse(formData.email);
+        if (!emailResult.success) {
+            setFieldErrors((prev) => ({ ...prev, email: "올바른 이메일 형식이 아닙니다." }));
+            return;
+        }
+        setEmailCheck({ status: CHECKING, checkedValue: formData.email });
+        try {
+            const { data } = await axiosInstance.get("/v1/auth/emails/check", {
+                params: { email: formData.email },
+            });
+            // TODO: 실제 응답 구조 확인 후 제거
+            console.log("[이메일 중복확인 응답]", data);
+            const available = data?.available ?? data?.data?.available;
+            setEmailCheck({
+                status: available ? AVAILABLE : UNAVAILABLE,
+                checkedValue: formData.email,
+            });
+            if (!available) {
+                setFieldErrors((prev) => ({ ...prev, email: "이미 사용 중인 이메일입니다." }));
+            } else {
+                setFieldErrors((prev) => ({ ...prev, email: undefined }));
+            }
+        } catch {
+            setEmailCheck({ status: IDLE, checkedValue: "" });
+            setFieldErrors((prev) => ({ ...prev, email: "중복 확인 중 오류가 발생했습니다." }));
+        }
+    };
+
+    const handleCheckNickname = async () => {
+        if (formData.nickname.length < 2 || formData.nickname.length > 50) {
+            setFieldErrors((prev) => ({
+                ...prev,
+                nickname: "닉네임은 2~50자 사이여야 합니다.",
+            }));
+            return;
+        }
+        setNicknameCheck({ status: CHECKING, checkedValue: formData.nickname });
+        try {
+            const { data } = await axiosInstance.get("/v1/auth/nicknames/check", {
+                params: { nickname: formData.nickname },
+            });
+            // TODO: 실제 응답 구조 확인 후 제거
+            console.log("[닉네임 중복확인 응답]", data);
+            const available = data?.available ?? data?.data?.available;
+            setNicknameCheck({
+                status: available ? AVAILABLE : UNAVAILABLE,
+                checkedValue: formData.nickname,
+            });
+            if (!available) {
+                setFieldErrors((prev) => ({
+                    ...prev,
+                    nickname: "이미 사용 중인 닉네임입니다.",
+                }));
+            } else {
+                setFieldErrors((prev) => ({ ...prev, nickname: undefined }));
+            }
+        } catch {
+            setNicknameCheck({ status: IDLE, checkedValue: "" });
+            setFieldErrors((prev) => ({
+                ...prev,
+                nickname: "중복 확인 중 오류가 발생했습니다.",
+            }));
+        }
+    };
+
+    const handleClearField = (name) => {
+        setFormData((prev) => ({ ...prev, [name]: "" }));
+        setFieldErrors((prev) => ({ ...prev, [name]: undefined }));
+        if (name === "email") {
+            setEmailCheck({ status: IDLE, checkedValue: "" });
+            setEmailVerif({ isSending: false, sent: false, code: "", isVerifying: false, verified: false, error: null });
+            stopCountdown();
+        }
+        if (name === "nickname") setNicknameCheck({ status: IDLE, checkedValue: "" });
+    };
+
+    const handleSendVerification = async () => {
+        setEmailVerif((prev) => ({ ...prev, isSending: true, error: null }));
+        try {
+            await axiosInstance.post("/v1/auth/emails/verification", {
+                email: formData.email,
+            });
+            setEmailVerif((prev) => ({ ...prev, isSending: false, sent: true, code: "", error: null }));
+            startCountdown();
+        } catch {
+            setEmailVerif((prev) => ({
+                ...prev,
+                isSending: false,
+                error: "인증번호 발송에 실패했습니다. 다시 시도해 주세요.",
+            }));
+        }
+    };
+
+    const handleVerifyCode = async () => {
+        if (!emailVerif.code.trim()) {
+            setEmailVerif((prev) => ({ ...prev, error: "인증번호를 입력해 주세요." }));
+            return;
+        }
+        setEmailVerif((prev) => ({ ...prev, isVerifying: true, error: null }));
+        try {
+            await axiosInstance.post("/v1/auth/emails/verification/confirm", {
+                email: formData.email,
+                code: emailVerif.code,
+            });
+            setEmailVerif((prev) => ({ ...prev, isVerifying: false, verified: true }));
+        } catch {
+            setEmailVerif((prev) => ({
+                ...prev,
+                isVerifying: false,
+                error: "인증번호가 올바르지 않습니다.",
+            }));
+        }
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setServerFeedback(null);
+
+        const result = joinSchema.safeParse(formData);
+        if (!result.success) {
+            const errors = {};
+            for (const issue of result.error.issues) {
+                const field = issue.path[0];
+                if (field && !errors[field]) errors[field] = issue.message;
+            }
+            setFieldErrors(errors);
+            return;
+        }
+
+        const emailPassed =
+            emailCheck.status === AVAILABLE && emailCheck.checkedValue === formData.email;
+        const nicknamePassed =
+            nicknameCheck.status === AVAILABLE && nicknameCheck.checkedValue === formData.nickname;
+
+        if (!emailPassed || !nicknamePassed) {
+            const errors = {};
+            if (!emailPassed) errors.email = "이메일 중복 확인을 해주세요.";
+            if (!nicknamePassed) errors.nickname = "닉네임 중복 확인을 해주세요.";
+            setFieldErrors((prev) => ({ ...prev, ...errors }));
+            return;
+        }
+
+        if (!emailVerif.verified) {
+            setEmailVerif((prev) => ({ ...prev, error: "이메일 인증을 완료해 주세요." }));
+            return;
+        }
+
+        setIsSubmitting(true);
+        try {
+            await axiosInstance.post("/v1/auth/signup", {
+                email: formData.email,
+                password: formData.password,
+                nickname: formData.nickname,
+            });
+            navigate("/auth/login", {
+                state: { message: "회원가입이 완료되었습니다. 로그인해 주세요." },
+            });
+        } catch (error) {
+            const msg =
+                error.response?.data?.message ||
+                "회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.";
+            setServerFeedback({ type: "error", message: msg });
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
     return (
         <div className="grid min-h-[70vh] place-items-center py-6">
-            <Card className="w-full max-w-md border-zinc-200/80 bg-white/95">
+            <Card className="w-full max-w-md border-zinc-200/80 bg-white/95 dark:border-zinc-700/80 dark:bg-zinc-900/95">
                 <CardHeader>
-                    <CardTitle className="text-xl font-bold text-zinc-900">회원가입</CardTitle>
+                    <CardTitle className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
+                        회원가입
+                    </CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-3">
-                    <Input type="text" placeholder="이름" />
-                    <Input type="email" placeholder="이메일" />
-                    <Input type="password" placeholder="비밀번호" />
-                    <Button className="w-full rounded-full bg-zinc-900 text-white hover:bg-zinc-700">가입하기</Button>
-                    <p className="text-center text-xs text-zinc-500">
-                        이미 계정이 있나요? <Link to="/auth/login" className="font-semibold text-zinc-900">로그인</Link>
-                    </p>
+                <CardContent>
+                    {serverFeedback?.type === "error" && (
+                        <Alert variant="destructive" className="mb-4">
+                            <AlertDescription>{serverFeedback.message}</AlertDescription>
+                        </Alert>
+                    )}
+
+                    <form noValidate onSubmit={handleSubmit} className="space-y-4">
+                        {/* 닉네임 */}
+                        <div>
+                            <label
+                                htmlFor="nickname"
+                                className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                            >
+                                닉네임
+                            </label>
+                            <div className="flex gap-2">
+                                <div className="relative flex-1">
+                                    <Input
+                                        id="nickname"
+                                        name="nickname"
+                                        type="text"
+                                        placeholder="2~50자"
+                                        value={formData.nickname}
+                                        onChange={handleChange}
+                                        aria-invalid={!!fieldErrors.nickname}
+                                        aria-describedby={fieldErrors.nickname ? "nickname-error" : undefined}
+                                        className="pr-8 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                                        disabled={isSubmitting}
+                                        autoComplete="nickname"
+                                    />
+                                    <span className="absolute right-2.5 top-1/2 -translate-y-1/2">
+                                        <CheckBadge status={nicknameCheck.status} />
+                                    </span>
+                                </div>
+                                {nicknameCheck.status === UNAVAILABLE ? (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => handleClearField("nickname")}
+                                        className="shrink-0 text-xs text-red-500 hover:text-red-600"
+                                    >
+                                        전체 삭제
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={handleCheckNickname}
+                                        disabled={isSubmitting || nicknameCheck.status === CHECKING || !formData.nickname}
+                                        className="shrink-0 text-xs"
+                                    >
+                                        {nicknameCheck.status === CHECKING ? "확인 중..." : "중복 확인"}
+                                    </Button>
+                                )}
+                            </div>
+                            <FieldError message={fieldErrors.nickname} id="nickname-error" />
+                        </div>
+
+                        {/* 이메일 */}
+                        <div>
+                            <label
+                                htmlFor="email"
+                                className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                            >
+                                이메일
+                            </label>
+                            <div className="flex gap-2">
+                                <div className="relative flex-1">
+                                    <Input
+                                        id="email"
+                                        name="email"
+                                        type="email"
+                                        placeholder="example@email.com"
+                                        value={formData.email}
+                                        onChange={handleChange}
+                                        aria-invalid={!!fieldErrors.email}
+                                        aria-describedby={fieldErrors.email ? "email-error" : undefined}
+                                        className="pr-8 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                                        disabled={isSubmitting || emailCheck.status === AVAILABLE}
+                                        autoComplete="email"
+                                    />
+                                    <span className="absolute right-2.5 top-1/2 -translate-y-1/2">
+                                        <CheckBadge status={emailCheck.status} />
+                                    </span>
+                                </div>
+                                {emailCheck.status === UNAVAILABLE ? (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => handleClearField("email")}
+                                        className="shrink-0 text-xs text-red-500 hover:text-red-600"
+                                    >
+                                        전체 삭제
+                                    </Button>
+                                ) : emailCheck.status === AVAILABLE ? (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => handleClearField("email")}
+                                        className="shrink-0 text-xs"
+                                    >
+                                        변경
+                                    </Button>
+                                ) : (
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={handleCheckEmail}
+                                        disabled={isSubmitting || emailCheck.status === CHECKING || !formData.email}
+                                        className="shrink-0 text-xs"
+                                    >
+                                        {emailCheck.status === CHECKING ? "확인 중..." : "중복 확인"}
+                                    </Button>
+                                )}
+                            </div>
+                            <FieldError message={fieldErrors.email} id="email-error" />
+
+                            {/* 인증번호 발송 영역: 이메일 중복확인 통과 후 표시 */}
+                            {emailCheck.status === AVAILABLE && !emailVerif.verified && (
+                                <div className="mt-2 space-y-2 rounded-md border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/50">
+                                    {!emailVerif.sent ? (
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={handleSendVerification}
+                                            disabled={emailVerif.isSending || isSubmitting}
+                                            className="w-full text-xs"
+                                        >
+                                            {emailVerif.isSending ? "발송 중..." : "인증번호 발송"}
+                                        </Button>
+                                    ) : (
+                                        <div className="flex gap-2">
+                                            <Input
+                                                type="text"
+                                                placeholder="인증번호 6자리"
+                                                value={emailVerif.code}
+                                                onChange={(e) =>
+                                                    setEmailVerif((prev) => ({ ...prev, code: e.target.value, error: null }))
+                                                }
+                                                maxLength={6}
+                                                className="h-8 flex-1 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+                                                disabled={isSubmitting}
+                                            />
+                                            <Button
+                                                type="button"
+                                                variant="outline"
+                                                size="sm"
+                                                onClick={handleVerifyCode}
+                                                disabled={emailVerif.isVerifying || isSubmitting}
+                                                className="shrink-0 text-xs"
+                                            >
+                                                {emailVerif.isVerifying ? "확인 중..." : "확인"}
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={handleSendVerification}
+                                                disabled={emailVerif.isSending || isSubmitting || countdown > 0}
+                                                className="shrink-0 text-xs text-zinc-400"
+                                            >
+                                                {countdown > 0
+                                                    ? formatCountdown(countdown)
+                                                    : "재발송"}
+                                            </Button>
+                                        </div>
+                                    )}
+                                    {emailVerif.error && (
+                                        <p className="text-xs text-red-500">{emailVerif.error}</p>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* 인증 완료 메시지 */}
+                            {emailVerif.verified && (
+                                <p className="mt-1.5 flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                                    <CheckCircle2 className="h-3.5 w-3.5" />
+                                    이메일 인증이 완료되었습니다.
+                                </p>
+                            )}
+                        </div>
+
+                        {/* 비밀번호 */}
+                        <div>
+                            <label
+                                htmlFor="password"
+                                className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                            >
+                                비밀번호
+                            </label>
+                            <div className="relative">
+                                <Input
+                                    id="password"
+                                    name="password"
+                                    type={showPassword ? "text" : "password"}
+                                    placeholder="8자 이상, 영문+숫자 포함"
+                                    value={formData.password}
+                                    onChange={handleChange}
+                                    aria-invalid={!!fieldErrors.password}
+                                    aria-describedby={fieldErrors.password ? "password-error" : undefined}
+                                    className="pr-10 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                                    disabled={isSubmitting}
+                                    autoComplete="new-password"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => setShowPassword((p) => !p)}
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+                                    aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 표시"}
+                                    tabIndex={-1}
+                                >
+                                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                </button>
+                            </div>
+                            <FieldError message={fieldErrors.password} id="password-error" />
+                        </div>
+
+                        {/* 비밀번호 확인 */}
+                        <div>
+                            <label
+                                htmlFor="confirmPassword"
+                                className="mb-1 block text-sm font-medium text-zinc-700 dark:text-zinc-300"
+                            >
+                                비밀번호 확인
+                            </label>
+                            <div className="relative">
+                                <Input
+                                    id="confirmPassword"
+                                    name="confirmPassword"
+                                    type={showConfirmPassword ? "text" : "password"}
+                                    placeholder="비밀번호 재입력"
+                                    value={formData.confirmPassword}
+                                    onChange={handleChange}
+                                    aria-invalid={!!fieldErrors.confirmPassword}
+                                    aria-describedby={
+                                        fieldErrors.confirmPassword ? "confirmPassword-error" : undefined
+                                    }
+                                    className="pr-10 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                                    disabled={isSubmitting}
+                                    autoComplete="new-password"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => setShowConfirmPassword((p) => !p)}
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+                                    aria-label={showConfirmPassword ? "비밀번호 숨기기" : "비밀번호 표시"}
+                                    tabIndex={-1}
+                                >
+                                    {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                                </button>
+                            </div>
+                            <FieldError message={fieldErrors.confirmPassword} id="confirmPassword-error" />
+                        </div>
+
+                        <Button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className="w-full rounded-full bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+                        >
+                            {isSubmitting ? "처리 중..." : "가입하기"}
+                        </Button>
+
+                        <p className="text-center text-xs text-zinc-500 dark:text-zinc-400">
+                            이미 계정이 있나요?{" "}
+                            <Link
+                                to="/auth/login"
+                                className="font-semibold text-zinc-900 hover:underline dark:text-zinc-100"
+                            >
+                                로그인
+                            </Link>
+                        </p>
+                    </form>
                 </CardContent>
             </Card>
         </div>

--- a/src/domains/client/auth/page/LoginPage.jsx
+++ b/src/domains/client/auth/page/LoginPage.jsx
@@ -1,22 +1,62 @@
-import { Link } from "react-router";
+import { useState } from "react";
+import { Link, useLocation } from "react-router";
 
+import { useKeycloak } from "@/common/auth/KeycloakProvider";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
 function LoginPage() {
+    const { login } = useKeycloak();
+    const [email, setEmail] = useState("");
+    const { state } = useLocation();
+
+    const handleLogin = (e) => {
+        e.preventDefault();
+        login({ loginHint: email });
+    };
+
     return (
         <div className="grid min-h-[70vh] place-items-center py-6">
-            <Card className="w-full max-w-md border-zinc-200/80 bg-white/95">
-                <CardHeader>
-                    <CardTitle className="text-xl font-bold text-zinc-900">로그인</CardTitle>
+            <Card className="w-full max-w-md border-zinc-200/80 bg-white/95 dark:border-zinc-700/80 dark:bg-zinc-900/95">
+                <CardHeader className="text-center">
+                    <CardTitle className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
+                        로그인
+                    </CardTitle>
+                    <CardDescription>Keycloak을 통해 안전하게 로그인하세요.</CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-3">
-                    <Input type="email" placeholder="이메일" />
-                    <Input type="password" placeholder="비밀번호" />
-                    <Button className="w-full rounded-full bg-zinc-900 text-white hover:bg-zinc-700">로그인</Button>
-                    <p className="text-center text-xs text-zinc-500">
-                        계정이 없나요? <Link to="/auth/join" className="font-semibold text-zinc-900">회원가입</Link>
+                <CardContent className="space-y-4">
+                    {state?.message && (
+                        <Alert className="border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400">
+                            <AlertDescription>{state.message}</AlertDescription>
+                        </Alert>
+                    )}
+                    <form onSubmit={handleLogin} className="space-y-3">
+                        <Input
+                            type="email"
+                            placeholder="이메일 주소"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            autoComplete="email"
+                            required
+                            className="dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:placeholder:text-zinc-500"
+                        />
+                        <Button
+                            type="submit"
+                            className="w-full rounded-full bg-zinc-900 text-white hover:bg-zinc-700 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-300"
+                        >
+                            로그인
+                        </Button>
+                    </form>
+                    <p className="text-center text-xs text-zinc-500 dark:text-zinc-400">
+                        계정이 없나요?{" "}
+                        <Link
+                            to="/auth/join"
+                            className="font-semibold text-zinc-900 hover:underline dark:text-zinc-100"
+                        >
+                            회원가입
+                        </Link>
                     </p>
                 </CardContent>
             </Card>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,13 +5,16 @@ import './css/index.css'
 import App from './App.jsx'
 import {BrowserRouter} from "react-router";
 import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
+import { KeycloakProvider } from '@/common/auth/KeycloakProvider.jsx';
 
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')).render(
     <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
+        <KeycloakProvider>
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+        </KeycloakProvider>
     </QueryClientProvider>
 )


### PR DESCRIPTION
## Summary

- Keycloak 인증 시스템 통합 (KeycloakProvider, silent SSO, Bearer 토큰 자동 주입)
- 회원가입 페이지 전면 구현: 닉네임/이메일 중복 확인, 이메일 인증 흐름, 재발송 쿨다운 타이머
- 로그인 페이지 Keycloak Authorization Code Flow 연동
- Header / UserNavigation 인증 상태 기반 UI 분기

Closes #3

---

## 변경 파일

| 파일 | 내용 |
|------|------|
| `src/common/auth/keycloak.js` | keycloak-js 인스턴스 설정 |
| `src/common/auth/KeycloakProvider.jsx` | 앱 전체 인증 컨텍스트 |
| `src/common/api/apiInstacne.js` | 요청/응답 인터셉터 추가 |
| `public/silent-check-sso.html` | Silent SSO 페이지 |
| `src/domains/client/auth/page/JoinPage.jsx` | 회원가입 폼 전면 구현 |
| `src/domains/client/auth/page/LoginPage.jsx` | Keycloak 로그인 연동 |
| `src/components/layout/Header.jsx` | 인증 상태 기반 UI |
| `src/components/layout/MainLayout.jsx` | 레이아웃 조정 |
| `src/components/user/UserNavigation.jsx` | 인증 상태 기반 네비게이션 |
| `src/main.jsx` | KeycloakProvider 래핑 |

## 회원가입 폼 상세 기능

- **중복 확인**: 닉네임/이메일 각각 별도 확인 버튼, 값 변경 시 상태 초기화
  - 사용 가능: 초록 체크
  - 사용 중:  빨간 X + **전체 삭제** 버튼
- **이메일 인증 흐름**: 중복 확인 통과 → 인증번호 발송 → 코드 입력/확인 → 재발송 쿨다운(5분)
- **가입 버튼**: 닉네임 중복 확인 + 이메일 중복 확인 + 이메일 인증 3가지 모두 통과해야 활성화

## Test plan

- [ ] 닉네임 중복 확인 — 사용 가능 / 사용 중 두 케이스
- [ ] 이메일 중복 확인 — 사용 가능 / 사용 중 두 케이스
- [ ] 전체 삭제 버튼 클릭 시 필드 초기화 및 상태 리셋 확인
- [ ] 인증번호 발송 후 카운트다운 타이머 작동 확인 (5분)
- [ ] 타이머 만료 후 재발송 버튼 활성화 확인
- [ ] 인증 완료 전 가입 버튼 클릭 시 차단 메시지 확인
- [ ] 회원가입 성공 후 로그인 페이지 리다이렉트 확인
- [ ] Keycloak 로그인 플로우 동작 확인

> **Note**: 백엔드 이메일 인증 엔드포인트 Keycloak Admin 401 오류 수정중 (#3)
