### PR TITLE
[feature] Checkout & Order 백엔드 API 데이터 바인딩

### DIFF
--- a/src/domains/client/checkout/api/checkoutApi.js
+++ b/src/domains/client/checkout/api/checkoutApi.js
@@ -1,0 +1,48 @@
+import { axiosInstance } from "@/common/api/apiInstacne";
+import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils";
+
+export async function reserveCheckout(cartItemIds = []) {
+    try {
+        const response = await axiosInstance.post("/v1/cart/checkout/reservations", {
+            cartItemIds,
+        });
+        return unwrapApiResponseBody(response, "체크아웃 예약에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "체크아웃 예약 요청에 실패했습니다.");
+    }
+}
+
+export async function fetchCheckoutQuote(orderId) {
+    try {
+        const response = await axiosInstance.post("/v1/sales/checkout/quotes", {
+            orderId,
+        });
+        return unwrapApiResponseBody(response, "가격 정보를 불러오지 못했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "가격 견적 조회에 실패했습니다.");
+    }
+}
+
+export async function submitCheckout({ orderId, shippingAddress, deliveryMessage }) {
+    try {
+        const response = await axiosInstance.post("/v1/sales/checkout/submit", {
+            orderId,
+            shippingAddress,
+            deliveryMessage,
+        });
+        return unwrapApiResponseBody(response, "주문 확정에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "주문 확정 요청에 실패했습니다.");
+    }
+}
+
+export async function cancelCheckout(orderId) {
+    try {
+        const response = await axiosInstance.post("/v1/sales/checkout/cancellations", {
+            orderId,
+        });
+        return unwrapApiResponseBody(response, "체크아웃 취소에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "체크아웃 취소 요청에 실패했습니다.");
+    }
+}

--- a/src/domains/client/checkout/lib/checkoutErrors.js
+++ b/src/domains/client/checkout/lib/checkoutErrors.js
@@ -1,0 +1,31 @@
+const SALES_ERROR_MESSAGES = {
+    "SALES-003": "잘못된 요청입니다.",
+    "SALES-100": "체크아웃 세션을 찾을 수 없습니다.",
+    "SALES-101": "체크아웃 세션이 만료되었습니다.",
+    "SALES-102": "이미 처리된 체크아웃입니다.",
+    "SALES-200": "상품 정보를 찾을 수 없습니다.",
+    "SALES-201": "판매가 종료된 상품입니다.",
+    "SALES-202": "구매 수량이 제한을 초과했습니다.",
+    "SALES-203": "재고가 부족합니다.",
+    "SALES-204": "예약이 만료되었습니다. 다시 시도해 주세요.",
+};
+
+export function getCheckoutErrorMessage(error) {
+    const code = error?.code;
+    if (code && SALES_ERROR_MESSAGES[code]) {
+        return SALES_ERROR_MESSAGES[code];
+    }
+    return error?.message || "주문 처리 중 오류가 발생했습니다.";
+}
+
+export function isStockInsufficient(error) {
+    return error?.code === "SALES-203" || error?.status === 409;
+}
+
+export function isReservationExpired(error) {
+    return error?.code === "SALES-204";
+}
+
+export function isSessionExpired(error) {
+    return error?.code === "SALES-101";
+}

--- a/src/domains/client/checkout/lib/checkoutMappers.js
+++ b/src/domains/client/checkout/lib/checkoutMappers.js
@@ -1,0 +1,67 @@
+import { formatPrice } from "@/domains/client/common/utils/format.js";
+
+function toNumber(value, fallback = 0) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+}
+
+function toText(value, fallback = "") {
+    return typeof value === "string" ? value.trim() : fallback;
+}
+
+export function mapCheckoutQuotePayload(raw) {
+    if (!raw) return null;
+
+    const items = Array.isArray(raw.items) ? raw.items.map(mapCheckoutItem) : [];
+    const subtotal = toNumber(raw.subtotal ?? raw.totalProductAmount);
+    const shippingFee = toNumber(raw.shippingFee ?? raw.deliveryFee);
+    const discountAmount = toNumber(raw.discountAmount);
+    const totalAmount = toNumber(raw.totalAmount, subtotal + shippingFee - discountAmount);
+
+    return {
+        orderId: toText(raw.orderId),
+        items,
+        subtotal,
+        subtotalText: formatPrice(subtotal),
+        shippingFee,
+        shippingFeeText: formatPrice(shippingFee),
+        discountAmount,
+        discountAmountText: formatPrice(discountAmount),
+        totalAmount,
+        totalAmountText: formatPrice(totalAmount),
+    };
+}
+
+function mapCheckoutItem(raw) {
+    return {
+        id: toText(raw.id ?? raw.itemId ?? raw.cartItemId),
+        name: toText(raw.name ?? raw.productName ?? raw.itemName),
+        option: toText(raw.option ?? raw.optionName),
+        thumbnail: toText(raw.thumbnail ?? raw.thumbnailUrl ?? raw.imageUrl),
+        storeName: toText(raw.storeName),
+        quantity: toNumber(raw.quantity, 1),
+        unitPrice: toNumber(raw.unitPrice ?? raw.price),
+        totalPrice: toNumber(raw.totalPrice ?? raw.unitPrice * raw.quantity),
+    };
+}
+
+export function mapReservationPayload(raw) {
+    if (!raw) return null;
+
+    return {
+        orderId: toText(raw.orderId),
+        reservedAt: toText(raw.reservedAt ?? raw.createdAt),
+        expiresAt: toText(raw.expiresAt),
+        items: Array.isArray(raw.items) ? raw.items.map(mapCheckoutItem) : [],
+    };
+}
+
+export function mapSubmitPayload(raw) {
+    if (!raw) return null;
+
+    return {
+        orderId: toText(raw.orderId),
+        status: toText(raw.status, "PAYMENT_PENDING"),
+        totalAmount: toNumber(raw.totalAmount),
+    };
+}

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -1,6 +1,14 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
-import { AlertCircle, BadgeCheck, CreditCard, MapPin, RefreshCw, ShieldCheck, TicketPercent } from "lucide-react";
+import {
+    AlertCircle,
+    CreditCard,
+    Loader2,
+    MapPin,
+    RefreshCw,
+    ShieldCheck,
+    TicketPercent,
+} from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button";
@@ -10,6 +18,16 @@ import { useCartQuery } from "@/domains/client/cart/query/useCartQueries";
 import { formatPrice, parsePriceText } from "@/domains/client/common/utils/format.js";
 import { coupons, paymentMethods, shippingAddresses } from "@/domains/client/order/mock/orderData.js";
 import { findStoreProduct } from "@/domains/client/store/mock/storeData.js";
+import {
+    useReserveCheckout,
+    useSubmitCheckout,
+    useCancelCheckout,
+} from "@/domains/client/checkout/query/useCheckoutQueries";
+import {
+    getCheckoutErrorMessage,
+    isStockInsufficient,
+    isReservationExpired,
+} from "@/domains/client/checkout/lib/checkoutErrors";
 
 function calculateCouponDiscount(selectedCoupon, subtotal, shippingFee) {
     if (!selectedCoupon) return 0;
@@ -38,10 +56,10 @@ function buildDirectCheckoutItem(storeId, productType, productId, ticketGrade, t
     const { store, product } = result;
     if (productType === "ticket") {
         const parsedQuantity = Number(ticketQuantity);
-        const requestedQuantity = Number.isFinite(parsedQuantity) && parsedQuantity > 0 ? Math.floor(parsedQuantity) : 1;
+        const requestedQuantity =
+            Number.isFinite(parsedQuantity) && parsedQuantity > 0 ? Math.floor(parsedQuantity) : 1;
         const selectedTier =
-            product.tiers.find((tier) => tier.grade === ticketGrade) ??
-            product.tiers[0];
+            product.tiers.find((tier) => tier.grade === ticketGrade) ?? product.tiers[0];
         const maxQuantity = Math.max(0, selectedTier?.remaining ?? 0);
         if (maxQuantity <= 0) return null;
 
@@ -52,7 +70,9 @@ function buildDirectCheckoutItem(storeId, productType, productId, ticketGrade, t
             storeId: store.id,
             storeName: store.name,
             name: product.name,
-            option: selectedTier ? `${selectedTier.grade} · ${product.eventDate}` : product.eventDate,
+            option: selectedTier
+                ? `${selectedTier.grade} · ${product.eventDate}`
+                : product.eventDate,
             thumbnail: product.thumbnail,
             quantity: safeQuantity,
             unitPrice: selectedTier ? parsePriceText(selectedTier.price) : 0,
@@ -79,7 +99,9 @@ function mapCartItemToCheckoutItem(item) {
         storeId: item.storeId,
         storeName: item.storeName,
         name: item.itemTitle,
-        option: item.salesStatus ? `${item.channelTypeLabel} · ${item.salesStatus}` : item.channelTypeLabel,
+        option: item.salesStatus
+            ? `${item.channelTypeLabel} · ${item.salesStatus}`
+            : item.channelTypeLabel,
         thumbnail: item.thumbnailUrl,
         quantity: item.quantity,
         unitPrice: item.unitPrice,
@@ -104,6 +126,7 @@ function CheckoutPage() {
     const directProductId = searchParams.get("productId") ?? "";
     const directTicketGrade = searchParams.get("ticketGrade") ?? "";
     const directTicketQuantity = searchParams.get("ticketQuantity") ?? "1";
+
     const {
         data: cart,
         isLoading: isCartLoading,
@@ -115,26 +138,43 @@ function CheckoutPage() {
         enabled: !directMode,
     });
 
+    // 체크아웃 API mutations
+    const reserveMutation = useReserveCheckout();
+    const submitMutation = useSubmitCheckout();
+    const cancelMutation = useCancelCheckout();
+
+    // 체크아웃 상태
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState(null);
+    const orderIdRef = useRef(null);
+
     const directItem = useMemo(
         () =>
             directMode
                 ? buildDirectCheckoutItem(
-                    directStoreId,
-                    directProductType,
-                    directProductId,
-                    directTicketGrade,
-                    directTicketQuantity
-                )
+                      directStoreId,
+                      directProductType,
+                      directProductId,
+                      directTicketGrade,
+                      directTicketQuantity,
+                  )
                 : null,
-        [directMode, directProductId, directProductType, directStoreId, directTicketGrade, directTicketQuantity]
+        [
+            directMode,
+            directProductId,
+            directProductType,
+            directStoreId,
+            directTicketGrade,
+            directTicketQuantity,
+        ],
     );
     const cartCheckoutItems = useMemo(
         () => (directMode ? [] : (cart?.selectedItems ?? []).map(mapCartItemToCheckoutItem)),
-        [cart?.selectedItems, directMode]
+        [cart?.selectedItems, directMode],
     );
     const checkoutItems = useMemo(
         () => (directMode ? (directItem ? [directItem] : []) : cartCheckoutItems),
-        [cartCheckoutItems, directItem, directMode]
+        [cartCheckoutItems, directItem, directMode],
     );
     const directBackLink = useMemo(() => {
         if (!directItem) return "/cart";
@@ -150,42 +190,105 @@ function CheckoutPage() {
         return `/store/${directItem.storeId}/product/${directProductType}/${directProductId}${ticketQuery}`;
     }, [directItem, directProductId, directProductType, directTicketGrade, directTicketQuantity]);
 
+    // 폼 상태 — 배송지/쿠폰/결제수단/포인트 (mock 기반)
     const [selectedAddressId, setSelectedAddressId] = useState(shippingAddresses[0]?.id ?? "");
     const [selectedCouponId, setSelectedCouponId] = useState("");
     const [selectedPaymentId, setSelectedPaymentId] = useState(paymentMethods[0]?.id ?? "");
     const [deliveryMessage, setDeliveryMessage] = useState("문 앞에 두고 벨 눌러주세요.");
     const [usedPoint, setUsedPoint] = useState(3000);
 
+    // 금액 계산
     const subtotal = useMemo(
         () => checkoutItems.reduce((sum, item) => sum + item.unitPrice * item.quantity, 0),
-        [checkoutItems]
+        [checkoutItems],
     );
     const shippingFee = subtotal >= 70000 ? 0 : 3500;
     const selectedCoupon = coupons.find((coupon) => coupon.id === selectedCouponId);
     const couponDiscount = calculateCouponDiscount(selectedCoupon, subtotal, shippingFee);
     const maxUsablePoint = Math.min(12000, subtotal - couponDiscount);
-    const safeUsedPoint = Math.min(Math.max(0, Number(usedPoint) || 0), Math.max(0, maxUsablePoint));
+    const safeUsedPoint = Math.min(
+        Math.max(0, Number(usedPoint) || 0),
+        Math.max(0, maxUsablePoint),
+    );
     const finalAmount = Math.max(0, subtotal + shippingFee - couponDiscount - safeUsedPoint);
 
-    const selectedAddress = shippingAddresses.find((address) => address.id === selectedAddressId) ?? shippingAddresses[0];
-    const selectedPayment = paymentMethods.find((method) => method.id === selectedPaymentId) ?? paymentMethods[0];
-    const isCheckoutReady = checkoutItems.length > 0;
+    const selectedAddress =
+        shippingAddresses.find((address) => address.id === selectedAddressId) ??
+        shippingAddresses[0];
+    const selectedPayment =
+        paymentMethods.find((method) => method.id === selectedPaymentId) ?? paymentMethods[0];
+    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting;
 
-    const submitCheckout = ({ success }) => {
+    // 체크아웃 3단계: reservations → (quotes 생략, 프론트 계산) → submit
+    const handleSubmitCheckout = async () => {
         if (!isCheckoutReady) return;
 
-        const orderId = `DM${Date.now()}`;
-        if (success) {
-            navigate(`/order/complete?orderId=${orderId}&amount=${finalAmount}`);
-            return;
+        setIsSubmitting(true);
+        setSubmitError(null);
+
+        try {
+            // Step 1: 재고 예약
+            const cartItemIds = checkoutItems.map((item) => item.id);
+            const reservation = await reserveMutation.mutateAsync(cartItemIds);
+            const orderId = reservation?.orderId;
+            orderIdRef.current = orderId;
+
+            // Step 2: 주문 확정 (배송정보 제출)
+            const result = await submitMutation.mutateAsync({
+                orderId,
+                shippingAddress: {
+                    receiver: selectedAddress.receiver,
+                    phone: selectedAddress.phone,
+                    zipCode: selectedAddress.zipCode,
+                    address1: selectedAddress.address1,
+                    address2: selectedAddress.address2,
+                },
+                deliveryMessage,
+            });
+
+            // TODO: Step 3 — 토스페이먼츠 결제 (Epic #28, Payment 서비스 완성 후)
+            // 현재는 submit 성공 = 주문 완료로 처리
+            navigate(
+                `/order/complete?orderId=${result?.orderId ?? orderId}&amount=${finalAmount}`,
+            );
+        } catch (error) {
+            setSubmitError(error);
+            setIsSubmitting(false);
+
+            // 예약까지 성공했으나 submit 실패 시 예약 취소
+            if (orderIdRef.current) {
+                cancelMutation.mutate(orderIdRef.current);
+                orderIdRef.current = null;
+            }
         }
-        navigate(`/order/fail?orderId=${orderId}&code=PAY_PROCESS_ERROR`);
     };
 
+    // 페이지 이탈 시 예약 취소 (예약 생성 후 결제 미완료 상태)
+    useEffect(() => {
+        const handleBeforeUnload = (e) => {
+            if (orderIdRef.current) {
+                e.preventDefault();
+            }
+        };
+        window.addEventListener("beforeunload", handleBeforeUnload);
+
+        return () => {
+            window.removeEventListener("beforeunload", handleBeforeUnload);
+            // 언마운트 시 예약이 남아있으면 취소
+            if (orderIdRef.current) {
+                cancelMutation.mutate(orderIdRef.current);
+                orderIdRef.current = null;
+            }
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    // --- 로딩 상태 ---
     if (!directMode && isCartLoading) {
         return <CheckoutPageSkeleton />;
     }
 
+    // --- 장바구니 에러 ---
     if (!directMode && isCartError) {
         return (
             <div className="grid min-h-[60vh] place-items-center">
@@ -197,11 +300,19 @@ function CheckoutPage() {
                         <Alert variant="destructive">
                             <AlertCircle className="h-4 w-4" />
                             <AlertTitle>장바구니 조회 실패</AlertTitle>
-                            <AlertDescription>{cartError?.message ?? "잠시 후 다시 시도해 주세요."}</AlertDescription>
+                            <AlertDescription>
+                                {cartError?.message ?? "잠시 후 다시 시도해 주세요."}
+                            </AlertDescription>
                         </Alert>
                         <div className="flex flex-wrap gap-2">
-                            <Button type="button" onClick={() => refetchCart()} disabled={isCartFetching}>
-                                <RefreshCw className={`h-4 w-4 ${isCartFetching ? "animate-spin" : ""}`} />
+                            <Button
+                                type="button"
+                                onClick={() => refetchCart()}
+                                disabled={isCartFetching}
+                            >
+                                <RefreshCw
+                                    className={`h-4 w-4 ${isCartFetching ? "animate-spin" : ""}`}
+                                />
                                 다시 시도
                             </Button>
                             <Button asChild variant="outline">
@@ -214,28 +325,49 @@ function CheckoutPage() {
         );
     }
 
+    // --- 주문 제출 중 ---
+    if (isSubmitting) {
+        return (
+            <div className="grid min-h-[60vh] place-items-center">
+                <div className="space-y-3 text-center">
+                    <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
+                    <p className="text-sm text-muted-foreground">주문을 처리하고 있습니다...</p>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="grid gap-5 lg:grid-cols-[1.1fr_0.9fr]">
             <div className="space-y-5">
                 <section className="rounded-3xl border border-border bg-card p-6 sm:p-8">
-                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">Checkout</p>
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                        Checkout
+                    </p>
                     <h2 className="mt-2 text-3xl font-black tracking-tight text-foreground">
-                        {directItem ? "바로 구매 주문서" : "주문서 / 결제"}
+                        주문서 / 결제
                     </h2>
                     <p className="mt-2 text-sm text-muted-foreground">
-                        결제 모듈은 토스페이먼츠 기준으로 설계되어 있고, 현재는 결제 성공/실패 화면만 프론트 데모로 연결되어 있습니다.
+                        주문 상품과 배송 정보를 확인한 후 결제를 진행해 주세요.
                     </p>
                     {directItem ? (
                         <p className="mt-2 rounded-xl border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-foreground">
-                            선택 상품: <span className="font-semibold">{directItem.name}</span> {directItem.quantity}건을 결제합니다.
+                            선택 상품:{" "}
+                            <span className="font-semibold">{directItem.name}</span>{" "}
+                            {directItem.quantity}건을 결제합니다.
                         </p>
                     ) : (
                         <p className="mt-2 rounded-xl border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-foreground">
-                            장바구니에서 선택한 상품 <span className="font-semibold">{cart?.selectedItemCount ?? checkoutItems.length}건</span>을 결제합니다.
+                            장바구니에서 선택한 상품{" "}
+                            <span className="font-semibold">
+                                {cart?.selectedItemCount ?? checkoutItems.length}건
+                            </span>
+                            을 결제합니다.
                         </p>
                     )}
                 </section>
 
+                {/* 배송지 선택 (mock) */}
                 <Card>
                     <CardHeader className="pb-3">
                         <CardTitle className="flex items-center gap-2 text-base">
@@ -256,7 +388,10 @@ function CheckoutPage() {
                                 }`}
                             >
                                 <p className="text-sm font-semibold">
-                                    {address.label} {address.isDefault && <span className="ml-1 text-xs opacity-80">기본 배송지</span>}
+                                    {address.label}{" "}
+                                    {address.isDefault && (
+                                        <span className="ml-1 text-xs opacity-80">기본 배송지</span>
+                                    )}
                                 </p>
                                 <p className="mt-1 text-sm">
                                     {address.receiver} · {address.phone}
@@ -268,7 +403,9 @@ function CheckoutPage() {
                         ))}
 
                         <div className="space-y-2 pt-1">
-                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">배송 요청사항</p>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                배송 요청사항
+                            </p>
                             <Input
                                 value={deliveryMessage}
                                 onChange={(event) => setDeliveryMessage(event.target.value)}
@@ -278,6 +415,7 @@ function CheckoutPage() {
                     </CardContent>
                 </Card>
 
+                {/* 결제 수단 (mock) */}
                 <Card>
                     <CardHeader className="pb-3">
                         <CardTitle className="flex items-center gap-2 text-base">
@@ -303,13 +441,15 @@ function CheckoutPage() {
                         ))}
 
                         <div className="rounded-2xl border border-primary/20 bg-primary/5 p-3 text-xs text-foreground">
-                            결제창 호출, 결제 승인/실패 콜백, 웹훅 검증은 실제 연동 시 토스페이먼츠 SDK로 연결합니다.
+                            결제창 호출, 결제 승인/실패 콜백, 웹훅 검증은 토스페이먼츠 SDK 연동 시
+                            활성화됩니다.
                         </div>
                     </CardContent>
                 </Card>
             </div>
 
             <div className="space-y-5 md:sticky md:top-24 md:self-start">
+                {/* 주문 상품 */}
                 <Card>
                     <CardHeader className="pb-3">
                         <CardTitle className="text-base">주문 상품</CardTitle>
@@ -317,21 +457,36 @@ function CheckoutPage() {
                     <CardContent className="space-y-3">
                         {checkoutItems.length > 0 ? (
                             checkoutItems.map((item) => (
-                                <div key={item.id} className="flex gap-3 rounded-xl border border-border bg-muted p-3">
+                                <div
+                                    key={item.id}
+                                    className="flex gap-3 rounded-xl border border-border bg-muted p-3"
+                                >
                                     {item.thumbnail ? (
-                                        <img src={item.thumbnail} alt={item.name} className="h-16 w-16 rounded-lg object-cover" />
+                                        <img
+                                            src={item.thumbnail}
+                                            alt={item.name}
+                                            className="h-16 w-16 rounded-lg object-cover"
+                                        />
                                     ) : (
                                         <div className="grid h-16 w-16 place-items-center rounded-lg bg-card text-xs text-muted-foreground">
                                             이미지 없음
                                         </div>
                                     )}
                                     <div className="min-w-0 flex-1">
-                                        <p className="text-xs text-muted-foreground">{item.storeName}</p>
-                                        <p className="line-clamp-1 text-sm font-semibold text-foreground">{item.name}</p>
-                                        <p className="line-clamp-1 text-xs text-muted-foreground">{item.option}</p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {item.storeName}
+                                        </p>
+                                        <p className="line-clamp-1 text-sm font-semibold text-foreground">
+                                            {item.name}
+                                        </p>
+                                        <p className="line-clamp-1 text-xs text-muted-foreground">
+                                            {item.option}
+                                        </p>
                                     </div>
                                     <div className="text-right">
-                                        <p className="text-xs text-muted-foreground">x {item.quantity}</p>
+                                        <p className="text-xs text-muted-foreground">
+                                            x {item.quantity}
+                                        </p>
                                         <p className="text-sm font-semibold text-foreground">
                                             {formatPrice(item.unitPrice * item.quantity)}
                                         </p>
@@ -348,6 +503,7 @@ function CheckoutPage() {
                     </CardContent>
                 </Card>
 
+                {/* 쿠폰 / 포인트 (mock) */}
                 <Card>
                     <CardHeader className="pb-2">
                         <CardTitle className="flex items-center gap-2 text-base">
@@ -357,7 +513,9 @@ function CheckoutPage() {
                     </CardHeader>
                     <CardContent className="space-y-3">
                         <div className="space-y-2">
-                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">쿠폰 선택</p>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                쿠폰 선택
+                            </p>
                             <div className="flex flex-wrap gap-2">
                                 <button
                                     type="button"
@@ -388,7 +546,9 @@ function CheckoutPage() {
                         </div>
 
                         <div className="space-y-2">
-                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">포인트 사용</p>
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                포인트 사용
+                            </p>
                             <Input
                                 type="number"
                                 min={0}
@@ -396,11 +556,14 @@ function CheckoutPage() {
                                 value={safeUsedPoint}
                                 onChange={(event) => setUsedPoint(event.target.value)}
                             />
-                            <p className="text-xs text-muted-foreground">최대 사용 가능 포인트: {maxUsablePoint.toLocaleString()}P</p>
+                            <p className="text-xs text-muted-foreground">
+                                최대 사용 가능 포인트: {maxUsablePoint.toLocaleString()}P
+                            </p>
                         </div>
                     </CardContent>
                 </Card>
 
+                {/* 최종 결제 금액 */}
                 <Card>
                     <CardHeader className="pb-2">
                         <CardTitle className="text-base">최종 결제 금액</CardTitle>
@@ -416,11 +579,15 @@ function CheckoutPage() {
                         </div>
                         <div className="flex items-center justify-between text-muted-foreground">
                             <span>쿠폰 할인</span>
-                            <span className="text-primary">- {formatPrice(couponDiscount)}</span>
+                            <span className="text-primary">
+                                - {formatPrice(couponDiscount)}
+                            </span>
                         </div>
                         <div className="flex items-center justify-between text-muted-foreground">
                             <span>포인트 사용</span>
-                            <span className="text-primary">- {formatPrice(safeUsedPoint)}</span>
+                            <span className="text-primary">
+                                - {formatPrice(safeUsedPoint)}
+                            </span>
                         </div>
                         <div className="my-2 h-px bg-border" />
                         <div className="flex items-center justify-between text-base font-bold text-foreground">
@@ -429,30 +596,44 @@ function CheckoutPage() {
                         </div>
 
                         <div className="rounded-2xl border border-border bg-muted p-3 text-xs text-muted-foreground">
-                            선택 결제수단: <span className="font-semibold text-foreground">{selectedPayment.name}</span>
+                            선택 결제수단:{" "}
+                            <span className="font-semibold text-foreground">
+                                {selectedPayment.name}
+                            </span>
                             <br />
-                            수령인: <span className="font-semibold text-foreground">{selectedAddress.receiver}</span>
+                            수령인:{" "}
+                            <span className="font-semibold text-foreground">
+                                {selectedAddress.receiver}
+                            </span>
                         </div>
+
+                        {/* 체크아웃 에러 표시 */}
+                        {submitError && (
+                            <Alert variant="destructive">
+                                <AlertCircle className="h-4 w-4" />
+                                <AlertTitle>
+                                    {isStockInsufficient(submitError)
+                                        ? "재고 부족"
+                                        : isReservationExpired(submitError)
+                                            ? "예약 만료"
+                                            : "주문 오류"}
+                                </AlertTitle>
+                                <AlertDescription>
+                                    {getCheckoutErrorMessage(submitError)}
+                                </AlertDescription>
+                            </Alert>
+                        )}
 
                         <Button
                             type="button"
-                            onClick={() => submitCheckout({ success: true })}
+                            onClick={handleSubmitCheckout}
                             disabled={!isCheckoutReady}
                             className="mt-2 h-10 w-full rounded-full text-sm font-semibold"
                         >
-                            토스페이먼츠 결제 요청
-                        </Button>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            onClick={() => submitCheckout({ success: false })}
-                            disabled={!isCheckoutReady}
-                            className="h-10 w-full rounded-full text-sm font-semibold"
-                        >
-                            실패 화면 테스트
+                            {formatPrice(finalAmount)} 결제하기
                         </Button>
                         <Button asChild variant="ghost" className="h-9 w-full rounded-full">
-                            <Link to={directBackLink}>
+                            <Link to={directItem ? directBackLink : "/cart"}>
                                 {directItem ? "상품 상세로 돌아가기" : "장바구니로 돌아가기"}
                             </Link>
                         </Button>
@@ -466,24 +647,11 @@ function CheckoutPage() {
                             Checkout 연결 상태
                         </p>
                         <p className="mt-1">
-                            장바구니 선택 상품은 실제 API 데이터로 렌더링 중입니다. 결제 승인과 주문 submit은 아직 프론트 데모 플로우입니다.
+                            주문 submit API가 연결되었습니다. 배송지/쿠폰/결제수단은 백엔드 서비스
+                            구현 후 교체 예정입니다.
                         </p>
                     </CardContent>
                 </Card>
-
-                {!directMode ? (
-                    <Card className="border-emerald-200/60 bg-emerald-50/70 dark:border-emerald-300/20 dark:bg-emerald-400/10">
-                        <CardContent className="p-4 text-xs text-emerald-900 dark:text-emerald-100">
-                            <p className="inline-flex items-center gap-1 font-semibold">
-                                <BadgeCheck className="h-3.5 w-3.5" />
-                                Cart 연동 완료
-                            </p>
-                            <p className="mt-1">
-                                결제 대상은 장바구니에서 체크된 상품만 반영됩니다. 선택 상태나 수량을 바꾸려면 장바구니로 돌아가서 수정하세요.
-                            </p>
-                        </CardContent>
-                    </Card>
-                ) : null}
             </div>
         </div>
     );

--- a/src/domains/client/checkout/query/useCheckoutQueries.js
+++ b/src/domains/client/checkout/query/useCheckoutQueries.js
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+    reserveCheckout,
+    fetchCheckoutQuote,
+    submitCheckout,
+    cancelCheckout,
+} from "@/domains/client/checkout/api/checkoutApi";
+import {
+    mapReservationPayload,
+    mapCheckoutQuotePayload,
+    mapSubmitPayload,
+} from "@/domains/client/checkout/lib/checkoutMappers";
+
+export function useReserveCheckout() {
+    return useMutation({
+        mutationFn: async (cartItemIds) => {
+            const payload = await reserveCheckout(cartItemIds);
+            return mapReservationPayload(payload);
+        },
+    });
+}
+
+export function useFetchCheckoutQuote() {
+    return useMutation({
+        mutationFn: async (orderId) => {
+            const payload = await fetchCheckoutQuote(orderId);
+            return mapCheckoutQuotePayload(payload);
+        },
+    });
+}
+
+export function useSubmitCheckout() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (params) => {
+            const payload = await submitCheckout(params);
+            return mapSubmitPayload(payload);
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["orders"] });
+        },
+    });
+}
+
+export function useCancelCheckout() {
+    return useMutation({
+        mutationFn: async (orderId) => {
+            return cancelCheckout(orderId);
+        },
+    });
+}

--- a/src/domains/client/order/api/orderApi.js
+++ b/src/domains/client/order/api/orderApi.js
@@ -1,0 +1,38 @@
+import { axiosInstance } from "@/common/api/apiInstacne";
+import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils";
+
+export async function fetchOrders(params = {}) {
+    try {
+        const response = await axiosInstance.get("/v1/orders", { params });
+        return unwrapApiResponseBody(response, "주문 목록을 불러오지 못했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "주문 목록 조회에 실패했습니다.");
+    }
+}
+
+export async function fetchOrderDetail(orderId) {
+    try {
+        const response = await axiosInstance.get(`/v1/orders/${orderId}`);
+        return unwrapApiResponseBody(response, "주문 정보를 불러오지 못했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "주문 상세 조회에 실패했습니다.");
+    }
+}
+
+export async function cancelOrder(orderId) {
+    try {
+        const response = await axiosInstance.post(`/v1/orders/${orderId}/cancel`);
+        return unwrapApiResponseBody(response, "주문 취소에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "주문 취소 요청에 실패했습니다.");
+    }
+}
+
+export async function refundOrder(orderId) {
+    try {
+        const response = await axiosInstance.post(`/v1/orders/${orderId}/refund`);
+        return unwrapApiResponseBody(response, "환불 요청에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "환불 요청에 실패했습니다.");
+    }
+}

--- a/src/domains/client/order/lib/orderMappers.js
+++ b/src/domains/client/order/lib/orderMappers.js
@@ -1,0 +1,129 @@
+import { formatPrice } from "@/domains/client/common/utils/format.js";
+
+function toNumber(value, fallback = 0) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+}
+
+function toText(value, fallback = "") {
+    return typeof value === "string" ? value.trim() : fallback;
+}
+
+const ORDER_STATUS_MAP = {
+    PAYMENT_PENDING: { label: "결제대기", className: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400" },
+    PAID: { label: "결제완료", className: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400" },
+    SHIPPING: { label: "배송중", className: "bg-primary/10 text-primary" },
+    DELIVERED: { label: "배송완료", className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400" },
+    COMPLETED: { label: "구매확정", className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400" },
+    CANCELLED: { label: "주문취소", className: "bg-destructive/10 text-destructive" },
+    REFUNDED: { label: "환불완료", className: "bg-destructive/10 text-destructive" },
+};
+
+export function mapOrderStatus(status) {
+    return ORDER_STATUS_MAP[status] ?? { label: status ?? "알 수 없음", className: "bg-muted text-muted-foreground" };
+}
+
+export function canCancelOrder(status) {
+    return status === "PAYMENT_PENDING";
+}
+
+export function canRefundOrder(status) {
+    return ["PAID", "SHIPPING", "DELIVERED", "COMPLETED"].includes(status);
+}
+
+function mapOrderItem(raw) {
+    return {
+        id: toText(raw.id ?? raw.itemId ?? raw.orderItemId),
+        name: toText(raw.name ?? raw.productName ?? raw.itemName),
+        option: toText(raw.option ?? raw.optionName),
+        thumbnail: toText(raw.thumbnail ?? raw.thumbnailUrl ?? raw.imageUrl),
+        storeName: toText(raw.storeName),
+        storeId: toText(raw.storeId),
+        quantity: toNumber(raw.quantity, 1),
+        unitPrice: toNumber(raw.unitPrice ?? raw.price),
+    };
+}
+
+function mapShipping(raw) {
+    if (!raw) return null;
+
+    return {
+        receiver: toText(raw.receiver ?? raw.recipientName),
+        phone: toText(raw.phone ?? raw.recipientPhone),
+        zipCode: toText(raw.zipCode ?? raw.postalCode),
+        address1: toText(raw.address1 ?? raw.address ?? raw.roadAddress),
+        address2: toText(raw.address2 ?? raw.detailAddress),
+        message: toText(raw.message ?? raw.deliveryMessage),
+        courier: toText(raw.courier ?? raw.carrierName),
+        trackingNo: toText(raw.trackingNo ?? raw.trackingNumber),
+    };
+}
+
+export function mapOrderListPayload(raw) {
+    if (!raw) return { orders: [], totalCount: 0, page: 0, size: 10 };
+
+    const content = Array.isArray(raw.content) ? raw.content : Array.isArray(raw) ? raw : [];
+
+    return {
+        orders: content.map(mapOrderSummary),
+        totalCount: toNumber(raw.totalElements ?? raw.totalCount ?? content.length),
+        page: toNumber(raw.number ?? raw.page),
+        size: toNumber(raw.size, 10),
+        totalPages: toNumber(raw.totalPages, 1),
+    };
+}
+
+function mapOrderSummary(raw) {
+    const status = mapOrderStatus(raw.status ?? raw.orderStatus);
+    const totalAmount = toNumber(raw.totalAmount ?? raw.totalPrice);
+
+    return {
+        id: toText(raw.id ?? raw.orderId),
+        status: raw.status ?? raw.orderStatus,
+        statusLabel: status.label,
+        statusClassName: status.className,
+        orderedAt: toText(raw.orderedAt ?? raw.createdAt ?? raw.orderDate),
+        totalAmount,
+        totalAmountText: formatPrice(totalAmount),
+        items: Array.isArray(raw.items ?? raw.orderItems) ? (raw.items ?? raw.orderItems).map(mapOrderItem) : [],
+    };
+}
+
+export function mapOrderDetailPayload(raw) {
+    if (!raw) return null;
+
+    const status = mapOrderStatus(raw.status ?? raw.orderStatus);
+    const totalAmount = toNumber(raw.totalAmount ?? raw.totalPrice);
+    const discountAmount = toNumber(raw.discountAmount);
+    const shippingFee = toNumber(raw.shippingFee ?? raw.deliveryFee);
+    const usedPoint = toNumber(raw.usedPoint ?? raw.pointUsed);
+    const subtotal = toNumber(raw.subtotal, totalAmount + discountAmount + usedPoint - shippingFee);
+
+    return {
+        id: toText(raw.id ?? raw.orderId),
+        status: raw.status ?? raw.orderStatus,
+        statusLabel: status.label,
+        statusClassName: status.className,
+        orderedAt: toText(raw.orderedAt ?? raw.createdAt ?? raw.orderDate),
+        paymentMethod: toText(raw.paymentMethod, "토스페이먼츠"),
+        items: Array.isArray(raw.items ?? raw.orderItems) ? (raw.items ?? raw.orderItems).map(mapOrderItem) : [],
+        shipping: mapShipping(raw.shipping ?? raw.shippingInfo ?? raw.deliveryInfo),
+        subtotal,
+        subtotalText: formatPrice(subtotal),
+        discountAmount,
+        discountAmountText: formatPrice(discountAmount),
+        shippingFee,
+        shippingFeeText: formatPrice(shippingFee),
+        usedPoint,
+        usedPointText: formatPrice(usedPoint),
+        totalAmount,
+        totalAmountText: formatPrice(totalAmount),
+        timeline: Array.isArray(raw.timeline ?? raw.orderTimeline)
+            ? (raw.timeline ?? raw.orderTimeline).map((step) => ({
+                label: toText(step.label ?? step.status),
+                at: toText(step.at ?? step.timestamp ?? step.createdAt),
+                done: Boolean(step.done ?? step.completed ?? step.at),
+            }))
+            : [],
+    };
+}

--- a/src/domains/client/order/page/OrderCompletePage.jsx
+++ b/src/domains/client/order/page/OrderCompletePage.jsx
@@ -1,14 +1,22 @@
 import { Link, useSearchParams } from "react-router";
-import { CheckCircle2, ReceiptText, Truck } from "lucide-react";
+import { CheckCircle2, Loader2, ReceiptText, Truck } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatPrice } from "@/domains/client/common/utils/format.js";
+import { useOrderDetailQuery } from "@/domains/client/order/query/useOrderQueries";
 
 function OrderCompletePage() {
     const [params] = useSearchParams();
-    const orderId = params.get("orderId") ?? "DM-DEMO-0001";
-    const amount = Number(params.get("amount") ?? 0);
+    const orderId = params.get("orderId") ?? "";
+    const fallbackAmount = Number(params.get("amount") ?? 0);
+
+    const { data: order, isLoading } = useOrderDetailQuery(orderId);
+
+    const displayAmount = order?.totalAmount ?? fallbackAmount;
+    const displayPayment = order?.paymentMethod ?? "토스페이먼츠";
+    const displayStatus = order?.statusLabel ?? "결제완료";
+    const orderItems = order?.items ?? [];
 
     return (
         <div className="mx-auto max-w-3xl space-y-6">
@@ -18,61 +26,147 @@ function OrderCompletePage() {
                 <p className="mt-2 text-sm">주문이 정상 접수되었고, 배송/티켓 발급 상태는 주문내역에서 확인할 수 있습니다.</p>
             </section>
 
-            <Card className="border-zinc-200/80 bg-white/95">
-                <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-base text-zinc-900">
-                        <CheckCircle2 className="h-4 w-4 text-emerald-600" />
-                        주문 정보
-                    </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-2 text-sm">
-                    <div className="flex items-center justify-between text-zinc-600">
-                        <span>주문번호</span>
-                        <span className="font-semibold text-zinc-900">{orderId}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-zinc-600">
-                        <span>결제금액</span>
-                        <span className="font-semibold text-zinc-900">{formatPrice(amount)}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-zinc-600">
-                        <span>결제수단</span>
-                        <span className="font-semibold text-zinc-900">토스페이먼츠</span>
-                    </div>
-                    <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3 text-xs text-zinc-600">
-                        티켓형 상품은 결제 즉시 마이페이지에서 확인 가능하며, 재고형 상품은 발송 후 송장 정보가 업데이트됩니다.
-                    </div>
-                </CardContent>
-            </Card>
+            {isLoading ? (
+                <div className="grid place-items-center py-8">
+                    <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                </div>
+            ) : (
+                <>
+                    <Card>
+                        <CardHeader className="pb-2">
+                            <CardTitle className="flex items-center gap-2 text-base">
+                                <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+                                주문 정보
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-2 text-sm">
+                            <div className="flex items-center justify-between text-muted-foreground">
+                                <span>주문번호</span>
+                                <span className="font-semibold text-foreground">{orderId}</span>
+                            </div>
+                            <div className="flex items-center justify-between text-muted-foreground">
+                                <span>결제금액</span>
+                                <span className="font-semibold text-foreground">{formatPrice(displayAmount)}</span>
+                            </div>
+                            <div className="flex items-center justify-between text-muted-foreground">
+                                <span>결제수단</span>
+                                <span className="font-semibold text-foreground">{displayPayment}</span>
+                            </div>
+                            <div className="flex items-center justify-between text-muted-foreground">
+                                <span>주문상태</span>
+                                <span className="font-semibold text-foreground">{displayStatus}</span>
+                            </div>
+
+                            {orderItems.length > 0 && (
+                                <div className="space-y-2 pt-2">
+                                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                        주문 상품
+                                    </p>
+                                    {orderItems.slice(0, 3).map((item) => (
+                                        <div
+                                            key={item.id}
+                                            className="flex items-center gap-3 rounded-xl border border-border bg-muted p-3"
+                                        >
+                                            {item.thumbnail && (
+                                                <img
+                                                    src={item.thumbnail}
+                                                    alt={item.name}
+                                                    className="h-12 w-12 rounded-lg object-cover"
+                                                />
+                                            )}
+                                            <div className="min-w-0 flex-1">
+                                                <p className="line-clamp-1 text-sm font-semibold text-foreground">
+                                                    {item.name}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground">
+                                                    {item.option} · x{item.quantity}
+                                                </p>
+                                            </div>
+                                            <p className="text-sm font-semibold text-foreground">
+                                                {formatPrice(item.unitPrice * item.quantity)}
+                                            </p>
+                                        </div>
+                                    ))}
+                                    {orderItems.length > 3 && (
+                                        <p className="text-xs text-muted-foreground">
+                                            외 {orderItems.length - 3}건
+                                        </p>
+                                    )}
+                                </div>
+                            )}
+
+                            <div className="rounded-xl border border-border bg-muted p-3 text-xs text-muted-foreground">
+                                티켓형 상품은 결제 즉시 마이페이지에서 확인 가능하며, 재고형 상품은 발송 후 송장 정보가 업데이트됩니다.
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {order && (
+                        <Card>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="text-base">결제 상세</CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-2 text-sm">
+                                <div className="flex items-center justify-between text-muted-foreground">
+                                    <span>상품 금액</span>
+                                    <span>{order.subtotalText}</span>
+                                </div>
+                                {order.discountAmount > 0 && (
+                                    <div className="flex items-center justify-between text-muted-foreground">
+                                        <span>할인</span>
+                                        <span className="text-primary">- {order.discountAmountText}</span>
+                                    </div>
+                                )}
+                                {order.usedPoint > 0 && (
+                                    <div className="flex items-center justify-between text-muted-foreground">
+                                        <span>포인트</span>
+                                        <span className="text-primary">- {order.usedPointText}</span>
+                                    </div>
+                                )}
+                                <div className="flex items-center justify-between text-muted-foreground">
+                                    <span>배송비</span>
+                                    <span>{order.shippingFeeText}</span>
+                                </div>
+                                <div className="my-1 h-px bg-border" />
+                                <div className="flex items-center justify-between text-base font-bold text-foreground">
+                                    <span>총 결제금액</span>
+                                    <span>{order.totalAmountText}</span>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    )}
+                </>
+            )}
 
             <section className="grid gap-3 sm:grid-cols-2">
-                <Card className="border-zinc-200/80 bg-white/95">
+                <Card>
                     <CardContent className="p-4 text-sm">
-                        <p className="inline-flex items-center gap-1 font-semibold text-zinc-900">
-                            <ReceiptText className="h-4 w-4 text-cyan-700" />
+                        <p className="inline-flex items-center gap-1 font-semibold text-foreground">
+                            <ReceiptText className="h-4 w-4 text-primary" />
                             주문내역 확인
                         </p>
-                        <p className="mt-1 text-zinc-600">주문 상태, 결제 정보, 취소/교환 신청을 한 곳에서 확인하세요.</p>
+                        <p className="mt-1 text-muted-foreground">주문 상태, 결제 정보, 취소/교환 신청을 한 곳에서 확인하세요.</p>
                     </CardContent>
                 </Card>
-                <Card className="border-zinc-200/80 bg-white/95">
+                <Card>
                     <CardContent className="p-4 text-sm">
-                        <p className="inline-flex items-center gap-1 font-semibold text-zinc-900">
-                            <Truck className="h-4 w-4 text-cyan-700" />
+                        <p className="inline-flex items-center gap-1 font-semibold text-foreground">
+                            <Truck className="h-4 w-4 text-primary" />
                             배송 상태 추적
                         </p>
-                        <p className="mt-1 text-zinc-600">송장 번호 연동 시 실시간 배송 위치와 도착 예정일을 제공합니다.</p>
+                        <p className="mt-1 text-muted-foreground">송장 번호 연동 시 실시간 배송 위치와 도착 예정일을 제공합니다.</p>
                     </CardContent>
                 </Card>
             </section>
 
             <div className="flex flex-wrap gap-2">
-                <Button asChild className="rounded-full bg-zinc-900 px-5 text-white hover:bg-zinc-700">
+                <Button asChild className="rounded-full px-5">
                     <Link to={`/my/orders/${orderId}`}>주문 상세 보기</Link>
                 </Button>
-                <Button asChild variant="outline" className="rounded-full border-zinc-300 bg-white px-5 text-zinc-700 hover:bg-zinc-100">
+                <Button asChild variant="outline" className="rounded-full px-5">
                     <Link to="/my/orders">주문내역 이동</Link>
                 </Button>
-                <Button asChild variant="ghost" className="rounded-full px-5 text-zinc-700 hover:bg-zinc-100">
+                <Button asChild variant="ghost" className="rounded-full px-5">
                     <Link to="/">홈으로 이동</Link>
                 </Button>
             </div>

--- a/src/domains/client/order/page/OrderDetailPage.jsx
+++ b/src/domains/client/order/page/OrderDetailPage.jsx
@@ -1,25 +1,56 @@
+import { useState } from "react";
 import { Link, useParams } from "react-router";
-import { PackageSearch } from "lucide-react";
+import { Loader2, PackageSearch } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { findOrderById } from "@/domains/client/order/mock/orderData.js";
 import { formatPrice } from "@/domains/client/common/utils/format.js";
+import {
+    useOrderDetailQuery,
+    useCancelOrderMutation,
+    useRefundOrderMutation,
+} from "@/domains/client/order/query/useOrderQueries";
+import { canCancelOrder, canRefundOrder } from "@/domains/client/order/lib/orderMappers";
 
 function OrderDetailPage() {
     const { orderId } = useParams();
-    const order = findOrderById(orderId);
+    const { data: order, isLoading, isError, error } = useOrderDetailQuery(orderId);
+    const cancelMutation = useCancelOrderMutation();
+    const refundMutation = useRefundOrderMutation();
 
-    if (!order) {
+    const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+    const [showRefundConfirm, setShowRefundConfirm] = useState(false);
+
+    const handleCancel = async () => {
+        await cancelMutation.mutateAsync(orderId);
+        setShowCancelConfirm(false);
+    };
+
+    const handleRefund = async () => {
+        await refundMutation.mutateAsync(orderId);
+        setShowRefundConfirm(false);
+    };
+
+    if (isLoading) {
         return (
             <div className="grid min-h-[60vh] place-items-center">
-                <Card className="w-full max-w-md border-zinc-200/80 bg-white/95">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+        );
+    }
+
+    if (isError || !order) {
+        return (
+            <div className="grid min-h-[60vh] place-items-center">
+                <Card className="w-full max-w-md">
                     <CardHeader>
-                        <CardTitle className="text-zinc-900">주문 정보를 찾을 수 없습니다</CardTitle>
+                        <CardTitle className="text-foreground">주문 정보를 찾을 수 없습니다</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-2">
-                        <p className="text-sm text-zinc-600">새로 생성된 주문은 아직 목데이터에 없을 수 있습니다.</p>
-                        <Button asChild className="rounded-full bg-zinc-900 px-5 text-white hover:bg-zinc-700">
+                        <p className="text-sm text-muted-foreground">
+                            {error?.message ?? "주문 정보를 불러올 수 없습니다."}
+                        </p>
+                        <Button asChild className="rounded-full px-5">
                             <Link to="/my/orders">주문내역으로 이동</Link>
                         </Button>
                     </CardContent>
@@ -30,109 +61,266 @@ function OrderDetailPage() {
 
     return (
         <div className="space-y-6">
-            <section className="rounded-3xl border border-zinc-200/80 bg-white/90 p-6 shadow-[0_14px_45px_rgba(15,23,42,0.08)] sm:p-8">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-700">Order Detail</p>
-                <h2 className="mt-2 text-3xl font-black tracking-tight text-zinc-900">주문 상세</h2>
-                <p className="mt-2 text-sm text-zinc-600">
-                    주문번호 <span className="font-semibold text-zinc-900">{order.id}</span> · {order.orderedAt}
+            <section className="rounded-3xl border border-border bg-card p-6 sm:p-8">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">Order Detail</p>
+                <h2 className="mt-2 text-3xl font-black tracking-tight text-foreground">주문 상세</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                    주문번호 <span className="font-semibold text-foreground">{order.id}</span> ·{" "}
+                    {order.orderedAt}
                 </p>
+                <span
+                    className={`mt-2 inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold ${order.statusClassName}`}
+                >
+                    {order.statusLabel}
+                </span>
             </section>
 
             <section className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
                 <div className="space-y-4">
-                    <Card className="border-zinc-200/80 bg-white/95">
+                    {/* 주문 상품 */}
+                    <Card>
                         <CardHeader className="pb-2">
-                            <CardTitle className="text-base text-zinc-900">주문 상품</CardTitle>
+                            <CardTitle className="text-base">주문 상품</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3">
                             {order.items.map((item) => (
-                                <div key={item.id} className="flex gap-3 rounded-xl border border-zinc-200 bg-zinc-50 p-3">
-                                    <img src={item.thumbnail} alt={item.name} className="h-16 w-16 rounded-lg object-cover" />
+                                <div
+                                    key={item.id}
+                                    className="flex gap-3 rounded-xl border border-border bg-muted p-3"
+                                >
+                                    <img
+                                        src={item.thumbnail}
+                                        alt={item.name}
+                                        className="h-16 w-16 rounded-lg object-cover"
+                                    />
                                     <div className="min-w-0 flex-1">
-                                        <p className="text-xs text-zinc-500">{item.storeName}</p>
-                                        <p className="line-clamp-1 text-sm font-semibold text-zinc-900">{item.name}</p>
-                                        <p className="line-clamp-1 text-xs text-zinc-500">{item.option}</p>
+                                        <p className="text-xs text-muted-foreground">{item.storeName}</p>
+                                        <p className="line-clamp-1 text-sm font-semibold text-foreground">
+                                            {item.name}
+                                        </p>
+                                        <p className="line-clamp-1 text-xs text-muted-foreground">
+                                            {item.option}
+                                        </p>
                                     </div>
                                     <div className="text-right">
-                                        <p className="text-xs text-zinc-500">x {item.quantity}</p>
-                                        <p className="text-sm font-semibold text-zinc-900">{formatPrice(item.unitPrice * item.quantity)}</p>
+                                        <p className="text-xs text-muted-foreground">x {item.quantity}</p>
+                                        <p className="text-sm font-semibold text-foreground">
+                                            {formatPrice(item.unitPrice * item.quantity)}
+                                        </p>
                                     </div>
                                 </div>
                             ))}
                         </CardContent>
                     </Card>
 
-                    <Card className="border-zinc-200/80 bg-white/95">
-                        <CardHeader className="pb-2">
-                            <CardTitle className="text-base text-zinc-900">배송 정보</CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-2 text-sm text-zinc-600">
-                            <p>수령인: {order.shipping.receiver}</p>
-                            <p>연락처: {order.shipping.phone}</p>
-                            <p>
-                                주소: ({order.shipping.zipCode}) {order.shipping.address1} {order.shipping.address2}
-                            </p>
-                            <p>요청사항: {order.shipping.message}</p>
-                            <p>택배사: {order.shipping.courier}</p>
-                            <p>송장번호: {order.shipping.trackingNo}</p>
-                        </CardContent>
-                    </Card>
+                    {/* 배송 정보 */}
+                    {order.shipping && (
+                        <Card>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="text-base">배송 정보</CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-2 text-sm text-muted-foreground">
+                                <p>
+                                    수령인:{" "}
+                                    <span className="text-foreground">{order.shipping.receiver}</span>
+                                </p>
+                                <p>
+                                    연락처:{" "}
+                                    <span className="text-foreground">{order.shipping.phone}</span>
+                                </p>
+                                <p>
+                                    주소:{" "}
+                                    <span className="text-foreground">
+                                        ({order.shipping.zipCode}) {order.shipping.address1}{" "}
+                                        {order.shipping.address2}
+                                    </span>
+                                </p>
+                                {order.shipping.message && (
+                                    <p>
+                                        요청사항:{" "}
+                                        <span className="text-foreground">{order.shipping.message}</span>
+                                    </p>
+                                )}
+                                {order.shipping.courier && (
+                                    <p>
+                                        택배사:{" "}
+                                        <span className="text-foreground">{order.shipping.courier}</span>
+                                    </p>
+                                )}
+                                {order.shipping.trackingNo && (
+                                    <p>
+                                        송장번호:{" "}
+                                        <span className="text-foreground">{order.shipping.trackingNo}</span>
+                                    </p>
+                                )}
+                            </CardContent>
+                        </Card>
+                    )}
                 </div>
 
                 <div className="space-y-4 md:sticky md:top-24 md:self-start">
-                    <Card className="border-zinc-200/80 bg-white/95">
+                    {/* 결제 정보 */}
+                    <Card>
                         <CardHeader className="pb-2">
-                            <CardTitle className="text-base text-zinc-900">결제 정보</CardTitle>
+                            <CardTitle className="text-base">결제 정보</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-2 text-sm">
-                            <div className="flex items-center justify-between text-zinc-600">
+                            <div className="flex items-center justify-between text-muted-foreground">
                                 <span>결제 수단</span>
-                                <span className="font-semibold text-zinc-900">{order.paymentMethod}</span>
+                                <span className="font-semibold text-foreground">
+                                    {order.paymentMethod}
+                                </span>
                             </div>
-                            <div className="flex items-center justify-between text-zinc-600">
+                            <div className="flex items-center justify-between text-muted-foreground">
                                 <span>상품 금액</span>
-                                <span>{formatPrice(order.totalAmount + order.discountAmount + order.usedPoint - order.shippingFee)}</span>
+                                <span>{order.subtotalText}</span>
                             </div>
-                            <div className="flex items-center justify-between text-zinc-600">
-                                <span>할인</span>
-                                <span>- {formatPrice(order.discountAmount)}</span>
-                            </div>
-                            <div className="flex items-center justify-between text-zinc-600">
-                                <span>포인트</span>
-                                <span>- {formatPrice(order.usedPoint)}</span>
-                            </div>
-                            <div className="flex items-center justify-between text-zinc-600">
-                                <span>배송비</span>
-                                <span>{formatPrice(order.shippingFee)}</span>
-                            </div>
-                            <div className="my-2 h-px bg-zinc-200" />
-                            <div className="flex items-center justify-between text-base font-bold text-zinc-900">
-                                <span>총 결제금액</span>
-                                <span>{formatPrice(order.totalAmount)}</span>
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    <Card className="border-zinc-200/80 bg-white/95">
-                        <CardHeader className="pb-2">
-                            <CardTitle className="flex items-center gap-2 text-base text-zinc-900">
-                                <PackageSearch className="h-4 w-4 text-cyan-700" />
-                                처리 상태
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-2">
-                            {order.timeline.map((step) => (
-                                <div key={step.label} className="rounded-xl border border-zinc-200 bg-zinc-50 p-3 text-sm">
-                                    <p className={`font-semibold ${step.done ? "text-zinc-900" : "text-zinc-400"}`}>{step.label}</p>
-                                    <p className={`text-xs ${step.done ? "text-zinc-500" : "text-zinc-400"}`}>{step.at}</p>
+                            {order.discountAmount > 0 && (
+                                <div className="flex items-center justify-between text-muted-foreground">
+                                    <span>할인</span>
+                                    <span className="text-primary">- {order.discountAmountText}</span>
                                 </div>
-                            ))}
+                            )}
+                            {order.usedPoint > 0 && (
+                                <div className="flex items-center justify-between text-muted-foreground">
+                                    <span>포인트</span>
+                                    <span className="text-primary">- {order.usedPointText}</span>
+                                </div>
+                            )}
+                            <div className="flex items-center justify-between text-muted-foreground">
+                                <span>배송비</span>
+                                <span>{order.shippingFeeText}</span>
+                            </div>
+                            <div className="my-2 h-px bg-border" />
+                            <div className="flex items-center justify-between text-base font-bold text-foreground">
+                                <span>총 결제금액</span>
+                                <span>{order.totalAmountText}</span>
+                            </div>
                         </CardContent>
                     </Card>
 
-                    <Button asChild variant="outline" className="h-10 w-full rounded-full border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-100">
-                        <Link to="/my/orders">주문내역으로 돌아가기</Link>
-                    </Button>
+                    {/* 처리 상태 타임라인 */}
+                    {order.timeline.length > 0 && (
+                        <Card>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="flex items-center gap-2 text-base">
+                                    <PackageSearch className="h-4 w-4 text-primary" />
+                                    처리 상태
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-2">
+                                {order.timeline.map((step) => (
+                                    <div
+                                        key={step.label}
+                                        className="rounded-xl border border-border bg-muted p-3 text-sm"
+                                    >
+                                        <p
+                                            className={`font-semibold ${step.done ? "text-foreground" : "text-muted-foreground"}`}
+                                        >
+                                            {step.label}
+                                        </p>
+                                        <p
+                                            className={`text-xs ${step.done ? "text-muted-foreground" : "text-muted-foreground/50"}`}
+                                        >
+                                            {step.at}
+                                        </p>
+                                    </div>
+                                ))}
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    {/* 주문 액션 */}
+                    <div className="space-y-2">
+                        {canCancelOrder(order.status) && !showCancelConfirm && (
+                            <Button
+                                variant="outline"
+                                className="h-10 w-full rounded-full border-destructive text-destructive hover:bg-destructive/10"
+                                onClick={() => setShowCancelConfirm(true)}
+                            >
+                                주문 취소
+                            </Button>
+                        )}
+                        {showCancelConfirm && (
+                            <Card className="border-destructive/30 bg-destructive/5">
+                                <CardContent className="space-y-3 p-4">
+                                    <p className="text-sm font-semibold text-destructive">
+                                        정말 주문을 취소하시겠습니까?
+                                    </p>
+                                    <div className="flex gap-2">
+                                        <Button
+                                            size="sm"
+                                            variant="destructive"
+                                            className="rounded-full"
+                                            disabled={cancelMutation.isPending}
+                                            onClick={handleCancel}
+                                        >
+                                            {cancelMutation.isPending ? "취소 중..." : "확인"}
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="rounded-full"
+                                            onClick={() => setShowCancelConfirm(false)}
+                                        >
+                                            돌아가기
+                                        </Button>
+                                    </div>
+                                    {cancelMutation.isError && (
+                                        <p className="text-xs text-destructive">
+                                            {cancelMutation.error?.message}
+                                        </p>
+                                    )}
+                                </CardContent>
+                            </Card>
+                        )}
+
+                        {canRefundOrder(order.status) && !showRefundConfirm && (
+                            <Button
+                                variant="outline"
+                                className="h-10 w-full rounded-full"
+                                onClick={() => setShowRefundConfirm(true)}
+                            >
+                                환불 요청
+                            </Button>
+                        )}
+                        {showRefundConfirm && (
+                            <Card className="border-amber-300/30 bg-amber-50 dark:bg-amber-900/10">
+                                <CardContent className="space-y-3 p-4">
+                                    <p className="text-sm font-semibold text-foreground">
+                                        환불을 요청하시겠습니까?
+                                    </p>
+                                    <div className="flex gap-2">
+                                        <Button
+                                            size="sm"
+                                            className="rounded-full"
+                                            disabled={refundMutation.isPending}
+                                            onClick={handleRefund}
+                                        >
+                                            {refundMutation.isPending ? "처리 중..." : "환불 요청"}
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="rounded-full"
+                                            onClick={() => setShowRefundConfirm(false)}
+                                        >
+                                            돌아가기
+                                        </Button>
+                                    </div>
+                                    {refundMutation.isError && (
+                                        <p className="text-xs text-destructive">
+                                            {refundMutation.error?.message}
+                                        </p>
+                                    )}
+                                </CardContent>
+                            </Card>
+                        )}
+
+                        <Button asChild variant="ghost" className="h-10 w-full rounded-full">
+                            <Link to="/my/orders">주문내역으로 돌아가기</Link>
+                        </Button>
+                    </div>
                 </div>
             </section>
         </div>

--- a/src/domains/client/order/page/OrderFailPage.jsx
+++ b/src/domains/client/order/page/OrderFailPage.jsx
@@ -5,57 +5,84 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const reasonMessages = {
+    // 결제 관련
     PAY_PROCESS_ERROR: "결제 처리 중 오류가 발생했습니다.",
     CARD_DECLINED: "카드 승인이 거절되었습니다.",
     USER_CANCELED: "사용자가 결제를 취소했습니다.",
+    // SALES 서비스 에러
+    "SALES-003": "잘못된 요청입니다.",
+    "SALES-100": "체크아웃 세션을 찾을 수 없습니다.",
+    "SALES-101": "체크아웃 세션이 만료되었습니다. 다시 시도해 주세요.",
+    "SALES-102": "이미 처리된 체크아웃입니다.",
+    "SALES-200": "상품 정보를 찾을 수 없습니다.",
+    "SALES-201": "판매가 종료된 상품입니다.",
+    "SALES-202": "구매 수량이 제한을 초과했습니다.",
+    "SALES-203": "재고가 부족합니다. 수량을 조정한 뒤 다시 시도해 주세요.",
+    "SALES-204": "예약이 만료되었습니다. 다시 시도해 주세요.",
 };
+
+const RETRYABLE_CODES = new Set([
+    "PAY_PROCESS_ERROR",
+    "SALES-101",
+    "SALES-203",
+    "SALES-204",
+]);
 
 function OrderFailPage() {
     const [params] = useSearchParams();
-    const orderId = params.get("orderId") ?? "DM-DEMO-0001";
+    const orderId = params.get("orderId") ?? "";
     const code = params.get("code") ?? "PAY_PROCESS_ERROR";
+    const message = params.get("message") ?? "";
+
+    const displayMessage =
+        reasonMessages[code] ?? (message || "알 수 없는 오류가 발생했습니다.");
+    const canRetry = RETRYABLE_CODES.has(code);
 
     return (
         <div className="mx-auto max-w-3xl space-y-6">
             <section className="rounded-3xl border border-rose-200 bg-rose-50/80 p-6 text-rose-900 shadow-[0_14px_45px_rgba(244,63,94,0.15)] sm:p-8 dark:border-rose-300/30 dark:bg-rose-400/10 dark:text-rose-100">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em]">Payment Failed</p>
                 <h2 className="mt-2 text-3xl font-black tracking-tight">결제에 실패했습니다</h2>
-                <p className="mt-2 text-sm">{reasonMessages[code] ?? "알 수 없는 오류가 발생했습니다."}</p>
+                <p className="mt-2 text-sm">{displayMessage}</p>
             </section>
 
-            <Card className="border-zinc-200/80 bg-white/95">
+            <Card>
                 <CardHeader className="pb-2">
-                    <CardTitle className="flex items-center gap-2 text-base text-zinc-900">
-                        <AlertTriangle className="h-4 w-4 text-rose-600" />
+                    <CardTitle className="flex items-center gap-2 text-base">
+                        <AlertTriangle className="h-4 w-4 text-destructive" />
                         오류 정보
                     </CardTitle>
                 </CardHeader>
-                <CardContent className="space-y-2 text-sm text-zinc-600">
-                    <div className="flex items-center justify-between">
-                        <span>주문번호</span>
-                        <span className="font-semibold text-zinc-900">{orderId}</span>
-                    </div>
-                    <div className="flex items-center justify-between">
+                <CardContent className="space-y-2 text-sm">
+                    {orderId && (
+                        <div className="flex items-center justify-between text-muted-foreground">
+                            <span>주문번호</span>
+                            <span className="font-semibold text-foreground">{orderId}</span>
+                        </div>
+                    )}
+                    <div className="flex items-center justify-between text-muted-foreground">
                         <span>오류 코드</span>
-                        <span className="font-semibold text-zinc-900">{code}</span>
+                        <span className="font-semibold text-foreground">{code}</span>
                     </div>
-                    <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-3 text-xs">
-                        반복 실패 시 다른 결제 수단을 선택하거나, 카드 한도/계좌 잔액을 확인한 뒤 다시 시도해 주세요.
+                    <div className="rounded-xl border border-border bg-muted p-3 text-xs text-muted-foreground">
+                        {canRetry
+                            ? "일시적 오류일 수 있습니다. 잠시 후 다시 시도해 주세요."
+                            : "반복 실패 시 다른 결제 수단을 선택하거나, 카드 한도/계좌 잔액을 확인한 뒤 다시 시도해 주세요."}
                     </div>
                 </CardContent>
             </Card>
 
             <div className="flex flex-wrap gap-2">
-                <Button asChild className="rounded-full bg-zinc-900 px-5 text-white hover:bg-zinc-700">
+                <Button asChild className="rounded-full px-5">
                     <Link to="/checkout">
                         <RefreshCw className="h-4 w-4" />
                         결제 다시 시도
                     </Link>
                 </Button>
-                <Button asChild variant="outline" className="rounded-full border-zinc-300 bg-white px-5 text-zinc-700 hover:bg-zinc-100">
+                <Button asChild variant="outline" className="rounded-full px-5">
                     <Link to="/cart">장바구니로 이동</Link>
                 </Button>
-                <Button asChild variant="ghost" className="rounded-full px-5 text-zinc-700 hover:bg-zinc-100">
+                <Button asChild variant="ghost" className="rounded-full px-5">
                     <Link to="/">홈으로 이동</Link>
                 </Button>
             </div>

--- a/src/domains/client/order/page/OrderListPage.jsx
+++ b/src/domains/client/order/page/OrderListPage.jsx
@@ -1,37 +1,77 @@
+import { useState } from "react";
 import { Link } from "react-router";
-import { ArrowRight, PackageCheck, Truck } from "lucide-react";
+import { ArrowRight, Loader2, PackageCheck, Truck } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { orderHistory } from "@/domains/client/order/mock/orderData.js";
-import { formatPrice } from "@/domains/client/common/utils/format.js";
+import { useOrdersQuery } from "@/domains/client/order/query/useOrderQueries";
 
-const statusFilters = ["전체", ...new Set(orderHistory.map((order) => order.status))];
-
-function statusClassName(status) {
-    if (status === "배송완료") return "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400";
-    if (status === "배송중") return "bg-primary/10 text-primary";
-    if (status === "결제취소") return "bg-destructive/10 text-destructive";
-    return "bg-muted text-muted-foreground";
-}
+const STATUS_FILTERS = [
+    { value: "", label: "전체" },
+    { value: "PAYMENT_PENDING", label: "결제대기" },
+    { value: "PAID", label: "결제완료" },
+    { value: "SHIPPING", label: "배송중" },
+    { value: "DELIVERED", label: "배송완료" },
+    { value: "COMPLETED", label: "구매확정" },
+    { value: "CANCELLED", label: "주문취소" },
+    { value: "REFUNDED", label: "환불완료" },
+];
 
 function OrderListPage() {
-    const shippingCount = orderHistory.filter((order) => order.status === "배송중").length;
-    const completeCount = orderHistory.filter((order) => order.status === "배송완료").length;
+    const [page, setPage] = useState(0);
+    const [statusFilter, setStatusFilter] = useState("");
+
+    const queryParams = { page, size: 10, ...(statusFilter && { status: statusFilter }) };
+    const { data, isLoading, isError, error } = useOrdersQuery(queryParams);
+
+    const orders = data?.orders ?? [];
+    const totalPages = data?.totalPages ?? 1;
+
+    const shippingCount = orders.filter((o) => o.status === "SHIPPING").length;
+    const completeCount = orders.filter(
+        (o) => o.status === "DELIVERED" || o.status === "COMPLETED",
+    ).length;
+
+    if (isLoading) {
+        return (
+            <div className="grid min-h-[60vh] place-items-center">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className="grid min-h-[60vh] place-items-center">
+                <Card className="w-full max-w-md">
+                    <CardHeader>
+                        <CardTitle className="text-destructive">주문 목록 조회 실패</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-sm text-muted-foreground">
+                            {error?.message ?? "잠시 후 다시 시도해 주세요."}
+                        </p>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
 
     return (
         <div className="space-y-6">
             <section className="rounded-3xl border border-border bg-card p-6 sm:p-8">
                 <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">My Orders</p>
                 <h2 className="mt-2 text-3xl font-black tracking-tight text-foreground">주문내역</h2>
-                <p className="mt-2 text-sm text-muted-foreground">결제/배송/취소 상태를 주문번호 단위로 확인할 수 있습니다.</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                    결제/배송/취소 상태를 주문번호 단위로 확인할 수 있습니다.
+                </p>
             </section>
 
             <section className="grid gap-3 sm:grid-cols-3">
                 <Card>
                     <CardContent className="p-4 text-sm">
                         <p className="text-muted-foreground">전체 주문</p>
-                        <p className="text-2xl font-bold text-foreground">{orderHistory.length}</p>
+                        <p className="text-2xl font-bold text-foreground">{data?.totalCount ?? 0}</p>
                     </CardContent>
                 </Card>
                 <Card>
@@ -59,50 +99,103 @@ function OrderListPage() {
                     <CardTitle className="text-base">주문 상태 필터</CardTitle>
                 </CardHeader>
                 <CardContent className="flex flex-wrap gap-2">
-                    {statusFilters.map((status) => (
-                        <span key={status} className="rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-muted-foreground">
-                            {status}
-                        </span>
+                    {STATUS_FILTERS.map((filter) => (
+                        <button
+                            key={filter.value}
+                            type="button"
+                            onClick={() => {
+                                setStatusFilter(filter.value);
+                                setPage(0);
+                            }}
+                            className={`rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors ${
+                                statusFilter === filter.value
+                                    ? "border-primary bg-primary text-primary-foreground"
+                                    : "border-border bg-muted text-muted-foreground hover:border-primary"
+                            }`}
+                        >
+                            {filter.label}
+                        </button>
                     ))}
                 </CardContent>
             </Card>
 
             <section className="space-y-3">
-                {orderHistory.map((order) => (
-                    <Card key={order.id}>
-                        <CardContent className="space-y-3 p-4">
-                            <div className="flex flex-wrap items-center justify-between gap-2">
-                                <div>
-                                    <p className="text-xs text-muted-foreground">{order.orderedAt}</p>
-                                    <p className="text-sm font-semibold text-foreground">{order.id}</p>
+                {orders.length > 0 ? (
+                    orders.map((order) => (
+                        <Card key={order.id}>
+                            <CardContent className="space-y-3 p-4">
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                    <div>
+                                        <p className="text-xs text-muted-foreground">{order.orderedAt}</p>
+                                        <p className="text-sm font-semibold text-foreground">{order.id}</p>
+                                    </div>
+                                    <span
+                                        className={`rounded-full px-2 py-0.5 text-xs font-semibold ${order.statusClassName}`}
+                                    >
+                                        {order.statusLabel}
+                                    </span>
                                 </div>
-                                <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${statusClassName(order.status)}`}>
-                                    {order.status}
-                                </span>
-                            </div>
 
-                            <div className="space-y-1 text-sm text-muted-foreground">
-                                {order.items.slice(0, 2).map((item) => (
-                                    <p key={item.id} className="line-clamp-1">
-                                        {item.name} · {item.option}
+                                <div className="space-y-1 text-sm text-muted-foreground">
+                                    {order.items.slice(0, 2).map((item) => (
+                                        <p key={item.id} className="line-clamp-1">
+                                            {item.name} · {item.option}
+                                        </p>
+                                    ))}
+                                    {order.items.length > 2 && (
+                                        <p className="text-xs">외 {order.items.length - 2}건</p>
+                                    )}
+                                </div>
+
+                                <div className="flex items-center justify-between">
+                                    <p className="text-sm font-semibold text-foreground">
+                                        {order.totalAmountText}
                                     </p>
-                                ))}
-                                {order.items.length > 2 && <p className="text-xs text-muted-foreground">외 {order.items.length - 2}건</p>}
-                            </div>
-
-                            <div className="flex items-center justify-between">
-                                <p className="text-sm font-semibold text-foreground">{formatPrice(order.totalAmount)}</p>
-                                <Button asChild size="sm" className="rounded-full px-4">
-                                    <Link to={`/my/orders/${order.id}`}>
-                                        상세 보기
-                                        <ArrowRight className="h-3.5 w-3.5" />
-                                    </Link>
-                                </Button>
-                            </div>
+                                    <Button asChild size="sm" className="rounded-full px-4">
+                                        <Link to={`/my/orders/${order.id}`}>
+                                            상세 보기
+                                            <ArrowRight className="h-3.5 w-3.5" />
+                                        </Link>
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    ))
+                ) : (
+                    <Card>
+                        <CardContent className="p-8 text-center text-sm text-muted-foreground">
+                            주문 내역이 없습니다.
                         </CardContent>
                     </Card>
-                ))}
+                )}
             </section>
+
+            {/* 페이지네이션 */}
+            {totalPages > 1 && (
+                <div className="flex items-center justify-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full"
+                        disabled={page === 0}
+                        onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    >
+                        이전
+                    </Button>
+                    <span className="text-sm text-muted-foreground">
+                        {page + 1} / {totalPages}
+                    </span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="rounded-full"
+                        disabled={page >= totalPages - 1}
+                        onClick={() => setPage((p) => p + 1)}
+                    >
+                        다음
+                    </Button>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/domains/client/order/query/useOrderQueries.js
+++ b/src/domains/client/order/query/useOrderQueries.js
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { shouldRetryRequest } from "@/common/api/queryRetry";
+import { fetchOrders, fetchOrderDetail, cancelOrder, refundOrder } from "@/domains/client/order/api/orderApi";
+import { mapOrderListPayload, mapOrderDetailPayload } from "@/domains/client/order/lib/orderMappers";
+
+export const orderKeys = {
+    all: ["orders"],
+    lists: () => [...orderKeys.all, "list"],
+    list: (params) => [...orderKeys.lists(), params],
+    details: () => [...orderKeys.all, "detail"],
+    detail: (orderId) => [...orderKeys.details(), orderId],
+};
+
+export function useOrdersQuery(params = {}) {
+    return useQuery({
+        queryKey: orderKeys.list(params),
+        queryFn: async () => {
+            const payload = await fetchOrders(params);
+            return mapOrderListPayload(payload);
+        },
+        retry: shouldRetryRequest,
+        staleTime: 30_000,
+    });
+}
+
+export function useOrderDetailQuery(orderId) {
+    return useQuery({
+        queryKey: orderKeys.detail(orderId),
+        queryFn: async () => {
+            const payload = await fetchOrderDetail(orderId);
+            return mapOrderDetailPayload(payload);
+        },
+        enabled: Boolean(orderId),
+        retry: shouldRetryRequest,
+        staleTime: 30_000,
+    });
+}
+
+export function useCancelOrderMutation() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: cancelOrder,
+        onSuccess: (_data, orderId) => {
+            queryClient.invalidateQueries({ queryKey: orderKeys.all });
+            queryClient.invalidateQueries({ queryKey: orderKeys.detail(orderId) });
+        },
+    });
+}
+
+export function useRefundOrderMutation() {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: refundOrder,
+        onSuccess: (_data, orderId) => {
+            queryClient.invalidateQueries({ queryKey: orderKeys.all });
+            queryClient.invalidateQueries({ queryKey: orderKeys.detail(orderId) });
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- Checkout 3단계 플로우(reservations → submit) API 연결 및 에러 핸들링
- Order CRUD(목록/상세/취소/환불) 전체 데이터 바인딩
- OrderCompletePage에서 실제 주문 상세 데이터 조회, OrderFailPage에 SALES 에러코드 12개 매핑
- 배송지/쿠폰/결제수단은 백엔드 미구현으로 mock 데이터 유지

## 변경 파일 (12개)

### Checkout 도메인
| 파일 | 설명 |
|------|------|
| `checkout/api/checkoutApi.js` | reserve, quote, submit, cancel API 레이어 |
| `checkout/lib/checkoutErrors.js` | SALES 에러코드 매핑 + 헬퍼 함수 |
| `checkout/lib/checkoutMappers.js` | 예약/견적/제출 응답 매퍼 |
| `checkout/query/useCheckoutQueries.js` | React Query mutation 훅 4개 |
| `checkout/page/CheckoutPage.jsx` | 3단계 API 연결, 이탈 시 예약 취소, 에러 표시 |

### Order 도메인
| 파일 | 설명 |
|------|------|
| `order/api/orderApi.js` | 목록/상세/취소/환불 API 레이어 |
| `order/lib/orderMappers.js` | 7개 주문 상태 매핑, 목록/상세 payload 변환 |
| `order/query/useOrderQueries.js` | Query 훅 2개 + Mutation 훅 2개 |
| `order/page/OrderListPage.jsx` | useOrdersQuery + 상태필터 + 페이지네이션 |
| `order/page/OrderDetailPage.jsx` | useOrderDetailQuery + 취소/환불 mutation |
| `order/page/OrderCompletePage.jsx` | useOrderDetailQuery로 실제 주문 데이터 표시 |
| `order/page/OrderFailPage.jsx` | SALES 에러코드 12개 + 재시도 가능 여부 분기 |

## 연관 이슈
- Epic: #26 (Cart + Checkout), #27 (Order 주문 관리)
- Story: #34, #35, #36, #37, #38
- Task: #41, #42, #43, #44, #45, #46, #47, #48, #49

## Test plan
- [ ] `/checkout` 페이지 진입 → 장바구니 상품 표시 확인
- [ ] 결제하기 클릭 → `/order/complete` 이동 + 주문 데이터 표시 확인
- [ ] `/my/orders` 주문 목록 조회 + 상태 필터 동작 확인
- [ ] `/my/orders/:id` 주문 상세 + 취소/환불 버튼 동작 확인
- [ ] 체크아웃 중 페이지 이탈 시 예약 취소 API 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)