### PR TITLE
Add .env.production for CloudFront deployment API URL

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=http://k8s-donmoadevgateway-3983261778-1519590243.ap-northeast-2.elb.amazonaws.com/api


### PR DESCRIPTION
## Summary
- `.env.production` 파일 추가 — `vite build` 시 `VITE_API_URL`이 번들에 인라인되도록 설정
- CloudFront 배포에서 API 요청이 `localhost:8071`로 가던 문제 해결

## 원인
`vite build`는 기본 모드가 production이라 `.env.production`을 읽는데, 이 파일이 없어서 `VITE_API_URL`이 비어있었음. fallback으로 `localhost:8071`이 사용되어 CloudFront 배포 환경에서 모든 API 호출 실패.

## Test plan
- [ ] develop 머지 후 GitHub Actions 배포 완료 확인
- [ ] CloudFront URL에서 회원가입 페이지 접속 → 닉네임/이메일 중복확인 API가 ELB 주소로 요청되는지 확인
