### PR TITLE
TossPayments customerKey를 실제 유저 ID로 변경

### DIFF
--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useCartQuery } from "@/domains/client/cart/query/useCartQueries";
+import { useAuthStore } from "@/common/store/useAuthStore.js";
 import { formatPrice, parsePriceText } from "@/domains/client/common/utils/format.js";
 import { coupons, shippingAddresses } from "@/domains/client/order/mock/orderData.js";
 import { findStoreProduct } from "@/domains/client/store/mock/storeData.js";
@@ -31,7 +32,6 @@ import {
 } from "@/domains/client/checkout/lib/checkoutErrors";
 
 const TOSS_CLIENT_KEY = "test_ck_5OWRapdA8dPQ40RPYJ6A8o1zEqZK";
-const TOSS_CUSTOMER_KEY = `don-moa-${Date.now()}`;
 
 function calculateCouponDiscount(selectedCoupon, subtotal, shippingFee) {
     if (!selectedCoupon) return 0;
@@ -129,6 +129,12 @@ function CheckoutPage() {
     const directProductId = searchParams.get("productId") ?? "";
     const directTicketGrade = searchParams.get("ticketGrade") ?? "";
     const directTicketQuantity = searchParams.get("ticketQuantity") ?? "1";
+
+    const user = useAuthStore((s) => s.user);
+    const tossCustomerKey = useMemo(
+        () => (user?.id ? `don-moa-${user.id}` : `don-moa-guest-${Date.now()}`),
+        [user?.id],
+    );
 
     const {
         data: cart,
@@ -248,7 +254,7 @@ function CheckoutPage() {
 
             // Step 3: 토스페이먼츠 결제창 호출
             const tossPayments = await loadTossPayments(TOSS_CLIENT_KEY);
-            const payment = tossPayments.payment({ customerKey: TOSS_CUSTOMER_KEY });
+            const payment = tossPayments.payment({ customerKey: tossCustomerKey });
 
             const orderName =
                 checkoutItems.length === 1


### PR DESCRIPTION
## Summary
- CheckoutPage의 `TOSS_CUSTOMER_KEY`를 `Date.now()` 기반에서 실제 로그인 유저 ID 기반으로 변경
- 미로그인 시 fallback으로 `don-moa-guest-{timestamp}` 사용

## 현재 바인딩 상태
| 영역 | 상태 | 비고 |
|------|------|------|
| 장바구니 CRUD | 실제 API | 완료 |
| 체크아웃 예약/제출 | 실제 API | 완료 |
| 토스페이먼츠 SDK | 실제 API | customerKey 수정 |
| 결제 확인(confirm) | 실제 API | 완료 |
| 주문 목록/상세/취소/환불 | 실제 API | 완료 |
| 배송지 | mock 유지 | 후속 작업 |
| 쿠폰 | mock 유지 | 후속 작업 |
| 상품 상세 직접구매 | mock 유지 | 상품 API 연동 시 함께 처리 |

## Test plan
- [ ] 로그인 후 체크아웃 → customerKey가 `don-moa-{userId}` 형태인지 확인
- [ ] 장바구니 → 주문하기 → 토스 결제창 → 결제 완료 플로우 정상 동작
- [ ] 빌드 에러 없음 확인 
