### PR TITLE
배송지 mock 데이터 제거 및 백엔드 API 연동

### DIFF
--- a/src/domains/client/account/page/MyPage.jsx
+++ b/src/domains/client/account/page/MyPage.jsx
@@ -3,8 +3,8 @@ import { Bell, MapPin, MessageCircleMore, Package, ReceiptText, TicketPercent, W
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { orderHistory } from "@/domains/client/order/mock/orderData.js";
 import { coupons, wishlistItems } from "@/domains/client/order/mock/orderData.js";
+import { useOrdersQuery } from "@/domains/client/order/query/useOrderQueries";
 
 const quickMenus = [
     { name: "주문내역", to: "/my/orders", icon: ReceiptText, desc: "주문/배송/취소 상태" },
@@ -16,7 +16,10 @@ const quickMenus = [
 ];
 
 function MyPage() {
-    const shippingCount = orderHistory.filter((order) => order.status === "배송중").length;
+    const { data: orderData, isLoading: isOrdersLoading, isError: isOrdersError } = useOrdersQuery();
+    const orders = orderData?.orders ?? [];
+    const orderCount = orderData?.totalCount ?? orders.length;
+    const shippingCount = orders.filter((order) => order.status === "SHIPPING").length;
 
     return (
         <div className="space-y-6">
@@ -30,13 +33,17 @@ function MyPage() {
                 <Card>
                     <CardContent className="p-4">
                         <p className="text-xs text-muted-foreground">최근 30일 주문</p>
-                        <p className="text-2xl font-bold text-foreground">{orderHistory.length}건</p>
+                        <p className="text-2xl font-bold text-foreground">
+                            {isOrdersLoading ? "…" : isOrdersError ? "-" : `${orderCount}건`}
+                        </p>
                     </CardContent>
                 </Card>
                 <Card>
                     <CardContent className="p-4">
                         <p className="text-xs text-muted-foreground">배송중</p>
-                        <p className="text-2xl font-bold text-foreground">{shippingCount}건</p>
+                        <p className="text-2xl font-bold text-foreground">
+                            {isOrdersLoading ? "…" : isOrdersError ? "-" : `${shippingCount}건`}
+                        </p>
                     </CardContent>
                 </Card>
                 <Card>

--- a/src/domains/client/address/api/addressApi.js
+++ b/src/domains/client/address/api/addressApi.js
@@ -15,7 +15,7 @@ export async function createAddress(data) {
         const response = await axiosInstance.post("/profile/addresses", data);
         return unwrapApiResponseBody(response, "배송지 추가에 실패했습니다.");
     } catch (error) {
-        throw normalizeApiError(error, "배송지 추가 요청에 실패했습니다.");
+        throw normalizeApiError(error, "배송지 추가에 실패했습니다.");
     }
 }
 
@@ -24,7 +24,7 @@ export async function updateAddress(addressId, data) {
         const response = await axiosInstance.put(`/profile/addresses/${addressId}`, data);
         return unwrapApiResponseBody(response, "배송지 수정에 실패했습니다.");
     } catch (error) {
-        throw normalizeApiError(error, "배송지 수정 요청에 실패했습니다.");
+        throw normalizeApiError(error, "배송지 수정에 실패했습니다.");
     }
 }
 
@@ -33,7 +33,7 @@ export async function deleteAddress(addressId) {
         const response = await axiosInstance.delete(`/profile/addresses/${addressId}`);
         return unwrapApiResponseBody(response, "배송지 삭제에 실패했습니다.");
     } catch (error) {
-        throw normalizeApiError(error, "배송지 삭제 요청에 실패했습니다.");
+        throw normalizeApiError(error, "배송지 삭제에 실패했습니다.");
     }
 }
 
@@ -42,6 +42,6 @@ export async function setDefaultAddress(addressId) {
         const response = await axiosInstance.patch(`/profile/addresses/${addressId}/default`);
         return unwrapApiResponseBody(response, "기본 배송지 설정에 실패했습니다.");
     } catch (error) {
-        throw normalizeApiError(error, "기본 배송지 설정 요청에 실패했습니다.");
+        throw normalizeApiError(error, "기본 배송지 설정에 실패했습니다.");
     }
 }

--- a/src/domains/client/address/api/addressApi.js
+++ b/src/domains/client/address/api/addressApi.js
@@ -1,0 +1,47 @@
+import { axiosInstance } from "@/common/api/apiInstacne";
+import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils";
+
+export async function fetchAddresses() {
+    try {
+        const response = await axiosInstance.get("/api/profile/addresses");
+        return unwrapApiResponseBody(response, "배송지 목록을 불러오지 못했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "배송지 목록 조회에 실패했습니다.");
+    }
+}
+
+export async function createAddress(data) {
+    try {
+        const response = await axiosInstance.post("/api/profile/addresses", data);
+        return unwrapApiResponseBody(response, "배송지 추가에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "배송지 추가 요청에 실패했습니다.");
+    }
+}
+
+export async function updateAddress(addressId, data) {
+    try {
+        const response = await axiosInstance.put(`/api/profile/addresses/${addressId}`, data);
+        return unwrapApiResponseBody(response, "배송지 수정에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "배송지 수정 요청에 실패했습니다.");
+    }
+}
+
+export async function deleteAddress(addressId) {
+    try {
+        const response = await axiosInstance.delete(`/api/profile/addresses/${addressId}`);
+        return unwrapApiResponseBody(response, "배송지 삭제에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "배송지 삭제 요청에 실패했습니다.");
+    }
+}
+
+export async function setDefaultAddress(addressId) {
+    try {
+        const response = await axiosInstance.patch(`/api/profile/addresses/${addressId}/default`);
+        return unwrapApiResponseBody(response, "기본 배송지 설정에 실패했습니다.");
+    } catch (error) {
+        throw normalizeApiError(error, "기본 배송지 설정 요청에 실패했습니다.");
+    }
+}

--- a/src/domains/client/address/api/addressApi.js
+++ b/src/domains/client/address/api/addressApi.js
@@ -30,8 +30,7 @@ export async function updateAddress(addressId, data) {
 
 export async function deleteAddress(addressId) {
     try {
-        const response = await axiosInstance.delete(`/profile/addresses/${addressId}`);
-        return unwrapApiResponseBody(response, "배송지 삭제에 실패했습니다.");
+        await axiosInstance.delete(`/profile/addresses/${addressId}`);
     } catch (error) {
         throw normalizeApiError(error, "배송지 삭제에 실패했습니다.");
     }
@@ -39,8 +38,7 @@ export async function deleteAddress(addressId) {
 
 export async function setDefaultAddress(addressId) {
     try {
-        const response = await axiosInstance.patch(`/profile/addresses/${addressId}/default`);
-        return unwrapApiResponseBody(response, "기본 배송지 설정에 실패했습니다.");
+        await axiosInstance.patch(`/profile/addresses/${addressId}/default`);
     } catch (error) {
         throw normalizeApiError(error, "기본 배송지 설정에 실패했습니다.");
     }

--- a/src/domains/client/address/api/addressApi.js
+++ b/src/domains/client/address/api/addressApi.js
@@ -3,7 +3,7 @@ import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseU
 
 export async function fetchAddresses() {
     try {
-        const response = await axiosInstance.get("/api/profile/addresses");
+        const response = await axiosInstance.get("/profile/addresses");
         return unwrapApiResponseBody(response, "배송지 목록을 불러오지 못했습니다.");
     } catch (error) {
         throw normalizeApiError(error, "배송지 목록 조회에 실패했습니다.");
@@ -12,7 +12,7 @@ export async function fetchAddresses() {
 
 export async function createAddress(data) {
     try {
-        const response = await axiosInstance.post("/api/profile/addresses", data);
+        const response = await axiosInstance.post("/profile/addresses", data);
         return unwrapApiResponseBody(response, "배송지 추가에 실패했습니다.");
     } catch (error) {
         throw normalizeApiError(error, "배송지 추가 요청에 실패했습니다.");
@@ -21,7 +21,7 @@ export async function createAddress(data) {
 
 export async function updateAddress(addressId, data) {
     try {
-        const response = await axiosInstance.put(`/api/profile/addresses/${addressId}`, data);
+        const response = await axiosInstance.put(`/profile/addresses/${addressId}`, data);
         return unwrapApiResponseBody(response, "배송지 수정에 실패했습니다.");
     } catch (error) {
         throw normalizeApiError(error, "배송지 수정 요청에 실패했습니다.");
@@ -30,7 +30,7 @@ export async function updateAddress(addressId, data) {
 
 export async function deleteAddress(addressId) {
     try {
-        const response = await axiosInstance.delete(`/api/profile/addresses/${addressId}`);
+        const response = await axiosInstance.delete(`/profile/addresses/${addressId}`);
         return unwrapApiResponseBody(response, "배송지 삭제에 실패했습니다.");
     } catch (error) {
         throw normalizeApiError(error, "배송지 삭제 요청에 실패했습니다.");
@@ -39,7 +39,7 @@ export async function deleteAddress(addressId) {
 
 export async function setDefaultAddress(addressId) {
     try {
-        const response = await axiosInstance.patch(`/api/profile/addresses/${addressId}/default`);
+        const response = await axiosInstance.patch(`/profile/addresses/${addressId}/default`);
         return unwrapApiResponseBody(response, "기본 배송지 설정에 실패했습니다.");
     } catch (error) {
         throw normalizeApiError(error, "기본 배송지 설정 요청에 실패했습니다.");

--- a/src/domains/client/address/page/AddressesPage.jsx
+++ b/src/domains/client/address/page/AddressesPage.jsx
@@ -1,10 +1,14 @@
-import { MapPin, Plus } from "lucide-react";
+import { Loader2, MapPin, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { shippingAddresses } from "@/domains/client/order/mock/orderData.js";
+import { useAddresses, useDeleteAddress, useSetDefaultAddress } from "@/domains/client/address/query/useAddressQueries";
 
 function AddressesPage() {
+    const { data: addresses, isLoading, isError, error } = useAddresses();
+    const deleteMutation = useDeleteAddress();
+    const setDefaultMutation = useSetDefaultAddress();
+
     return (
         <div className="space-y-6">
             <section className="rounded-3xl border border-border bg-card p-6 sm:p-8">
@@ -20,41 +24,76 @@ function AddressesPage() {
                 </Button>
             </div>
 
-            <section className="space-y-3">
-                {shippingAddresses.map((address) => (
-                    <Card key={address.id}>
-                        <CardHeader className="pb-2">
-                            <CardTitle className="flex items-center gap-2 text-base">
-                                <MapPin className="h-4 w-4 text-primary" />
-                                {address.label}
-                                {address.isDefault && (
-                                    <span className="rounded-full bg-primary px-2 py-0.5 text-[11px] font-semibold text-primary-foreground">
-                                        기본
-                                    </span>
-                                )}
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="space-y-1 text-sm text-muted-foreground">
-                            <p>
-                                {address.receiver} · {address.phone}
-                            </p>
-                            <p>
-                                ({address.zipCode}) {address.address1} {address.address2}
-                            </p>
-                            <div className="flex gap-2 pt-2">
-                                <Button size="sm" variant="outline" className="rounded-full px-4">
-                                    수정
-                                </Button>
-                                {!address.isDefault && (
+            {isLoading && (
+                <div className="flex items-center justify-center py-12">
+                    <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                </div>
+            )}
+
+            {isError && (
+                <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                    배송지를 불러오지 못했습니다. {error?.message ?? "잠시 후 다시 시도해 주세요."}
+                </div>
+            )}
+
+            {!isLoading && !isError && addresses?.length === 0 && (
+                <div className="rounded-2xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+                    등록된 배송지가 없습니다. 새 배송지를 추가해 보세요.
+                </div>
+            )}
+
+            {!isLoading && !isError && addresses?.length > 0 && (
+                <section className="space-y-3">
+                    {addresses.map((address) => (
+                        <Card key={address.id}>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="flex items-center gap-2 text-base">
+                                    <MapPin className="h-4 w-4 text-primary" />
+                                    {address.deliveryName}
+                                    {address.isDefault && (
+                                        <span className="rounded-full bg-primary px-2 py-0.5 text-[11px] font-semibold text-primary-foreground">
+                                            기본
+                                        </span>
+                                    )}
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-1 text-sm text-muted-foreground">
+                                <p>
+                                    {address.recipientName} · {address.recipientPhone}
+                                </p>
+                                <p>
+                                    ({address.zipcode}) {address.fullAddress}
+                                </p>
+                                <div className="flex gap-2 pt-2">
                                     <Button size="sm" variant="outline" className="rounded-full px-4">
-                                        기본 설정
+                                        수정
                                     </Button>
-                                )}
-                            </div>
-                        </CardContent>
-                    </Card>
-                ))}
-            </section>
+                                    {!address.isDefault && (
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="rounded-full px-4"
+                                            disabled={setDefaultMutation.isPending}
+                                            onClick={() => setDefaultMutation.mutate(address.id)}
+                                        >
+                                            기본 설정
+                                        </Button>
+                                    )}
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="rounded-full px-4 text-destructive hover:text-destructive"
+                                        disabled={deleteMutation.isPending}
+                                        onClick={() => deleteMutation.mutate(address.id)}
+                                    >
+                                        삭제
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+            )}
         </div>
     );
 }

--- a/src/domains/client/address/page/AddressesPage.jsx
+++ b/src/domains/client/address/page/AddressesPage.jsx
@@ -1,99 +1,83 @@
-import { Loader2, MapPin, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { useAddresses, useDeleteAddress, useSetDefaultAddress } from "@/domains/client/address/query/useAddressQueries";
+import AddressDeleteConfirmModal from "@/domains/client/address/components/AddressDeleteConfirmModal";
+import AddressFormModal from "@/domains/client/address/components/AddressFormModal";
+import AddressList from "@/domains/client/address/components/AddressList";
+import {
+    useAddressListQuery,
+    useDeleteAddress,
+    useSetDefaultAddress,
+} from "@/domains/client/address/hook/useAddressQuery";
 
 function AddressesPage() {
-    const { data: addresses, isLoading, isError, error } = useAddresses();
+    const { data: addresses = [], isLoading, isError } = useAddressListQuery();
+
     const deleteMutation = useDeleteAddress();
     const setDefaultMutation = useSetDefaultAddress();
 
+    const [formModal, setFormModal] = useState({ open: false, address: null });
+    const [deleteModal, setDeleteModal] = useState({ open: false, addressId: null });
+
+    const handleOpenCreate = () => setFormModal({ open: true, address: null });
+    const handleOpenEdit = (address) => setFormModal({ open: true, address });
+    const handleCloseForm = () => setFormModal({ open: false, address: null });
+
+    const handleOpenDelete = (addressId) => setDeleteModal({ open: true, addressId });
+    const handleCloseDelete = () => setDeleteModal({ open: false, addressId: null });
+
+    const handleConfirmDelete = async () => {
+        await deleteMutation.mutateAsync(deleteModal.addressId);
+        handleCloseDelete();
+    };
+
+    const handleSetDefault = (addressId) => {
+        setDefaultMutation.mutate(addressId);
+    };
+
     return (
-        <div className="space-y-6">
+        <div className="space-y-6 max-w-2xl mx-auto pb-10">
             <section className="rounded-3xl border border-border bg-card p-6 sm:p-8">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">Shipping Addresses</p>
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+                    Shipping Addresses
+                </p>
                 <h2 className="mt-2 text-3xl font-black tracking-tight text-foreground">배송지 관리</h2>
-                <p className="mt-2 text-sm text-muted-foreground">자주 쓰는 배송지를 등록/수정해서 주문서 작성 시간을 줄일 수 있습니다.</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                    자주 쓰는 배송지를 등록/수정해서 주문서 작성 시간을 줄일 수 있습니다.
+                </p>
             </section>
 
             <div className="flex justify-end">
-                <Button className="rounded-full px-5">
+                <Button className="rounded-full px-5" onClick={handleOpenCreate}>
                     <Plus className="h-4 w-4" />
                     새 배송지 추가
                 </Button>
             </div>
 
-            {isLoading && (
-                <div className="flex items-center justify-center py-12">
-                    <Loader2 className="h-6 w-6 animate-spin text-primary" />
-                </div>
-            )}
+            <AddressList
+                addresses={addresses}
+                isLoading={isLoading}
+                isError={isError}
+                onEdit={handleOpenEdit}
+                onDelete={handleOpenDelete}
+                onSetDefault={handleSetDefault}
+                isSettingDefault={setDefaultMutation.isPending}
+            />
 
-            {isError && (
-                <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-                    배송지를 불러오지 못했습니다. {error?.message ?? "잠시 후 다시 시도해 주세요."}
-                </div>
-            )}
+            <AddressFormModal
+                key={formModal.address?.id ?? "create"}
+                open={formModal.open}
+                onClose={handleCloseForm}
+                address={formModal.address}
+            />
 
-            {!isLoading && !isError && addresses?.length === 0 && (
-                <div className="rounded-2xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
-                    등록된 배송지가 없습니다. 새 배송지를 추가해 보세요.
-                </div>
-            )}
-
-            {!isLoading && !isError && addresses?.length > 0 && (
-                <section className="space-y-3">
-                    {addresses.map((address) => (
-                        <Card key={address.id}>
-                            <CardHeader className="pb-2">
-                                <CardTitle className="flex items-center gap-2 text-base">
-                                    <MapPin className="h-4 w-4 text-primary" />
-                                    {address.deliveryName}
-                                    {address.isDefault && (
-                                        <span className="rounded-full bg-primary px-2 py-0.5 text-[11px] font-semibold text-primary-foreground">
-                                            기본
-                                        </span>
-                                    )}
-                                </CardTitle>
-                            </CardHeader>
-                            <CardContent className="space-y-1 text-sm text-muted-foreground">
-                                <p>
-                                    {address.recipientName} · {address.recipientPhone}
-                                </p>
-                                <p>
-                                    ({address.zipcode}) {address.fullAddress}
-                                </p>
-                                <div className="flex gap-2 pt-2">
-                                    <Button size="sm" variant="outline" className="rounded-full px-4">
-                                        수정
-                                    </Button>
-                                    {!address.isDefault && (
-                                        <Button
-                                            size="sm"
-                                            variant="outline"
-                                            className="rounded-full px-4"
-                                            disabled={setDefaultMutation.isPending}
-                                            onClick={() => setDefaultMutation.mutate(address.id)}
-                                        >
-                                            기본 설정
-                                        </Button>
-                                    )}
-                                    <Button
-                                        size="sm"
-                                        variant="outline"
-                                        className="rounded-full px-4 text-destructive hover:text-destructive"
-                                        disabled={deleteMutation.isPending}
-                                        onClick={() => deleteMutation.mutate(address.id)}
-                                    >
-                                        삭제
-                                    </Button>
-                                </div>
-                            </CardContent>
-                        </Card>
-                    ))}
-                </section>
-            )}
+            <AddressDeleteConfirmModal
+                open={deleteModal.open}
+                onClose={handleCloseDelete}
+                onConfirm={handleConfirmDelete}
+                isPending={deleteMutation.isPending}
+            />
         </div>
     );
 }

--- a/src/domains/client/address/query/useAddressQueries.js
+++ b/src/domains/client/address/query/useAddressQueries.js
@@ -1,0 +1,56 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+    fetchAddresses,
+    createAddress,
+    updateAddress,
+    deleteAddress,
+    setDefaultAddress,
+} from "@/domains/client/address/api/addressApi";
+
+export function useAddresses() {
+    return useQuery({
+        queryKey: ["addresses"],
+        queryFn: fetchAddresses,
+    });
+}
+
+export function useCreateAddress() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data) => createAddress(data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["addresses"] });
+        },
+    });
+}
+
+export function useUpdateAddress() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ addressId, data }) => updateAddress(addressId, data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["addresses"] });
+        },
+    });
+}
+
+export function useDeleteAddress() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (addressId) => deleteAddress(addressId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["addresses"] });
+        },
+    });
+}
+
+export function useSetDefaultAddress() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (addressId) => setDefaultAddress(addressId),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["addresses"] });
+        },
+    });
+}

--- a/src/domains/client/checkout/api/checkoutApi.js
+++ b/src/domains/client/checkout/api/checkoutApi.js
@@ -23,12 +23,14 @@ export async function fetchCheckoutQuote(orderId) {
     }
 }
 
-export async function submitCheckout({ orderId, shippingAddress, deliveryMessage }) {
+export async function submitCheckout({ orderId, recipientName, recipientPhone, deliveryAddressId, deliveryMemo }) {
     try {
         const response = await axiosInstance.post("/v1/sales/checkout/submit", {
             orderId,
-            shippingAddress,
-            deliveryMessage,
+            recipientName,
+            recipientPhone,
+            deliveryAddressId,
+            deliveryMemo,
         });
         return unwrapApiResponseBody(response, "주문 확정에 실패했습니다.");
     } catch (error) {

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -18,7 +18,8 @@ import { Input } from "@/components/ui/input";
 import { useCartQuery } from "@/domains/client/cart/query/useCartQueries";
 import { useAuthStore } from "@/common/store/useAuthStore.js";
 import { formatPrice, parsePriceText } from "@/domains/client/common/utils/format.js";
-import { coupons, shippingAddresses } from "@/domains/client/order/mock/orderData.js";
+import { coupons } from "@/domains/client/order/mock/orderData.js";
+import { useAddresses } from "@/domains/client/address/query/useAddressQueries";
 import { findStoreProduct } from "@/domains/client/store/mock/storeData.js";
 import {
     useReserveCheckout,
@@ -147,6 +148,9 @@ function CheckoutPage() {
         enabled: !directMode,
     });
 
+    // 배송지 조회
+    const { data: addresses = [] } = useAddresses();
+
     // 체크아웃 API mutations
     const reserveMutation = useReserveCheckout();
     const submitMutation = useSubmitCheckout();
@@ -199,8 +203,16 @@ function CheckoutPage() {
         return `/store/${directItem.storeId}/product/${directProductType}/${directProductId}${ticketQuery}`;
     }, [directItem, directProductId, directProductType, directTicketGrade, directTicketQuantity]);
 
-    // 폼 상태 — 배송지/쿠폰/결제수단/포인트 (mock 기반)
-    const [selectedAddressId, setSelectedAddressId] = useState(shippingAddresses[0]?.id ?? "");
+    // 폼 상태 — 배송지/쿠폰/결제수단/포인트
+    const [selectedAddressId, setSelectedAddressId] = useState("");
+
+    // 기본 배송지를 초기 선택값으로 설정
+    useEffect(() => {
+        if (addresses.length > 0 && !selectedAddressId) {
+            const defaultAddress = addresses.find((a) => a.isDefault) ?? addresses[0];
+            setSelectedAddressId(defaultAddress.id);
+        }
+    }, [addresses, selectedAddressId]);
     const [selectedCouponId, setSelectedCouponId] = useState("");
     const [deliveryMessage, setDeliveryMessage] = useState("문 앞에 두고 벨 눌러주세요.");
     const [usedPoint, setUsedPoint] = useState(3000);
@@ -221,8 +233,7 @@ function CheckoutPage() {
     const finalAmount = Math.max(0, subtotal + shippingFee - couponDiscount - safeUsedPoint);
 
     const selectedAddress =
-        shippingAddresses.find((address) => address.id === selectedAddressId) ??
-        shippingAddresses[0];
+        addresses.find((address) => address.id === selectedAddressId) ?? addresses[0];
     const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting;
 
     // 체크아웃: reservations → submit → 토스 결제창
@@ -242,14 +253,10 @@ function CheckoutPage() {
             // Step 2: 주문 확정 (배송정보 제출) → PENDING_PAYMENT 상태
             await submitMutation.mutateAsync({
                 orderId,
-                shippingAddress: {
-                    receiver: selectedAddress.receiver,
-                    phone: selectedAddress.phone,
-                    zipCode: selectedAddress.zipCode,
-                    address1: selectedAddress.address1,
-                    address2: selectedAddress.address2,
-                },
-                deliveryMessage,
+                recipientName: selectedAddress.recipientName,
+                recipientPhone: selectedAddress.recipientPhone,
+                deliveryAddressId: selectedAddress.id,
+                deliveryMemo: deliveryMessage,
             });
 
             // Step 3: 토스페이먼츠 결제창 호출
@@ -266,7 +273,7 @@ function CheckoutPage() {
                 amount: { currency: "KRW", value: finalAmount },
                 orderId,
                 orderName,
-                customerName: selectedAddress.receiver,
+                customerName: selectedAddress?.recipientName ?? "",
                 successUrl: `${window.location.origin}/order/complete?orderId=${orderId}&amount=${finalAmount}`,
                 failUrl: `${window.location.origin}/order/fail?orderId=${orderId}`,
             });
@@ -394,7 +401,7 @@ function CheckoutPage() {
                     )}
                 </section>
 
-                {/* 배송지 선택 (mock) */}
+                {/* 배송지 선택 */}
                 <Card>
                     <CardHeader className="pb-3">
                         <CardTitle className="flex items-center gap-2 text-base">
@@ -403,31 +410,37 @@ function CheckoutPage() {
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3">
-                        {shippingAddresses.map((address) => (
-                            <button
-                                key={address.id}
-                                type="button"
-                                onClick={() => setSelectedAddressId(address.id)}
-                                className={`w-full rounded-2xl border p-4 text-left transition-colors ${
-                                    selectedAddressId === address.id
-                                        ? "border-primary bg-primary text-primary-foreground"
-                                        : "border-border bg-card text-foreground hover:border-primary"
-                                }`}
-                            >
-                                <p className="text-sm font-semibold">
-                                    {address.label}{" "}
-                                    {address.isDefault && (
-                                        <span className="ml-1 text-xs opacity-80">기본 배송지</span>
-                                    )}
-                                </p>
-                                <p className="mt-1 text-sm">
-                                    {address.receiver} · {address.phone}
-                                </p>
-                                <p className="mt-1 text-xs opacity-85">
-                                    ({address.zipCode}) {address.address1} {address.address2}
-                                </p>
-                            </button>
-                        ))}
+                        {addresses.length === 0 ? (
+                            <p className="rounded-2xl border border-border bg-muted p-4 text-sm text-muted-foreground">
+                                등록된 배송지가 없습니다. 배송지 관리 페이지에서 배송지를 추가해 주세요.
+                            </p>
+                        ) : (
+                            addresses.map((address) => (
+                                <button
+                                    key={address.id}
+                                    type="button"
+                                    onClick={() => setSelectedAddressId(address.id)}
+                                    className={`w-full rounded-2xl border p-4 text-left transition-colors ${
+                                        selectedAddressId === address.id
+                                            ? "border-primary bg-primary text-primary-foreground"
+                                            : "border-border bg-card text-foreground hover:border-primary"
+                                    }`}
+                                >
+                                    <p className="text-sm font-semibold">
+                                        {address.deliveryName}{" "}
+                                        {address.isDefault && (
+                                            <span className="ml-1 text-xs opacity-80">기본 배송지</span>
+                                        )}
+                                    </p>
+                                    <p className="mt-1 text-sm">
+                                        {address.recipientName} · {address.recipientPhone}
+                                    </p>
+                                    <p className="mt-1 text-xs opacity-85">
+                                        ({address.zipcode}) {address.fullAddress}
+                                    </p>
+                                </button>
+                            ))
+                        )}
 
                         <div className="space-y-2 pt-1">
                             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -617,7 +630,7 @@ function CheckoutPage() {
                             <br />
                             수령인:{" "}
                             <span className="font-semibold text-foreground">
-                                {selectedAddress.receiver}
+                                {selectedAddress?.recipientName ?? "-"}
                             </span>
                         </div>
 
@@ -662,7 +675,7 @@ function CheckoutPage() {
                         </p>
                         <p className="mt-1">
                             체크아웃 API + 토스페이먼츠 테스트 모드가 연동되어 있습니다.
-                            배송지/쿠폰은 백엔드 서비스 구현 후 교체 예정입니다.
+                            배송지는 profile-service와 연동됩니다.
                         </p>
                     </CardContent>
                 </Card>

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useCartQuery } from "@/domains/client/cart/query/useCartQueries";
+import { useAuthStore } from "@/common/store/useAuthStore.js";
 import { formatPrice, parsePriceText } from "@/domains/client/common/utils/format.js";
 import { coupons, shippingAddresses } from "@/domains/client/order/mock/orderData.js";
 import { findStoreProduct } from "@/domains/client/store/mock/storeData.js";
@@ -31,7 +32,6 @@ import {
 } from "@/domains/client/checkout/lib/checkoutErrors";
 
 const TOSS_CLIENT_KEY = "test_ck_5OWRapdA8dPQ40RPYJ6A8o1zEqZK";
-const TOSS_CUSTOMER_KEY = `don-moa-${Date.now()}`;
 
 function calculateCouponDiscount(selectedCoupon, subtotal, shippingFee) {
     if (!selectedCoupon) return 0;
@@ -129,6 +129,12 @@ function CheckoutPage() {
     const directProductId = searchParams.get("productId") ?? "";
     const directTicketGrade = searchParams.get("ticketGrade") ?? "";
     const directTicketQuantity = searchParams.get("ticketQuantity") ?? "1";
+
+    const user = useAuthStore((s) => s.user);
+    const tossCustomerKey = useMemo(
+        () => (user?.id ? `don-moa-${user.id}` : `don-moa-guest-${Date.now()}`),
+        [user?.id],
+    );
 
     const {
         data: cart,
@@ -248,7 +254,7 @@ function CheckoutPage() {
 
             // Step 3: 토스페이먼츠 결제창 호출
             const tossPayments = await loadTossPayments(TOSS_CLIENT_KEY);
-            const payment = tossPayments.payment({ customerKey: TOSS_CUSTOMER_KEY });
+            const payment = tossPayments.payment({ customerKey: tossCustomerKey });
 
             const orderName =
                 checkoutItems.length === 1

--- a/src/domains/client/order/mock/orderData.js
+++ b/src/domains/client/order/mock/orderData.js
@@ -37,29 +37,6 @@ export const cartItems = [
     },
 ];
 
-export const shippingAddresses = [
-    {
-        id: "addr-main",
-        label: "집",
-        receiver: "김도윤",
-        phone: "010-1234-5678",
-        zipCode: "06134",
-        address1: "서울특별시 강남구 테헤란로 123",
-        address2: "801호",
-        isDefault: true,
-    },
-    {
-        id: "addr-office",
-        label: "회사",
-        receiver: "김도윤",
-        phone: "010-2222-8899",
-        zipCode: "04525",
-        address1: "서울특별시 중구 세종대로 110",
-        address2: "11층",
-        isDefault: false,
-    },
-];
-
 export const coupons = [
     {
         id: "coupon-welcome-12k",


### PR DESCRIPTION
closes #63

## 개요

`AddressesPage`와 `CheckoutPage`에서 사용하던 `orderData.js`의 mock `shippingAddresses`를 완전히 제거하고, 백엔드 profile-service의 배송지 CRUD API로 교체합니다.

## 변경 사항

### 신규 파일
- **`src/domains/client/address/api/addressApi.js`**
  - `fetchAddresses` / `createAddress` / `updateAddress` / `deleteAddress` / `setDefaultAddress` 5개 함수
  - `axiosInstance` + `normalizeApiError` + `unwrapApiResponseBody` 패턴 적용

- **`src/domains/client/address/query/useAddressQueries.js`**
  - `useAddresses` (useQuery, queryKey: `["addresses"]`)
  - `useCreateAddress` / `useUpdateAddress` / `useDeleteAddress` / `useSetDefaultAddress` (useMutation, onSuccess → invalidate `["addresses"]`)

### 수정 파일

| 파일 | 변경 내용 |
|------|-----------|
| `AddressesPage.jsx` | mock import 제거, `useAddresses` 훅 연동, 로딩/에러/빈 목록 UI 추가, 필드 매핑 변경(`label→deliveryName` 등), 삭제 버튼 추가 |
| `CheckoutPage.jsx` | mock import 제거(`coupons`만 유지), `useAddresses` 훅 연동, `useEffect`로 기본 배송지 자동 선택, 필드 매핑 변경, 빈 배송지 안내 UI 추가 |
| `checkoutApi.js` | `submitCheckout` 파라미터를 `{ orderId, recipientName, recipientPhone, deliveryAddressId, deliveryMemo }`로 변경 |
| `orderData.js` | `shippingAddresses` export 삭제 (다른 파일에서 참조 없음 확인) |

## 확인 사항

- [x] `coupons`, `paymentMethods` 등 나머지 mock 데이터는 그대로 유지
- [x] 배송지 목록이 비어있을 때 신규 유저 안내 UI 추가
- [x] `axiosInstance` import 경로 오타(`apiInstacne`) 기존 코드 그대로 유지