### PR TITLE
fix: 주문서/ 결제 idempotencyKey UUID 누락 수정 

### DIFF
--- a/src/domains/client/checkout/api/checkoutApi.js
+++ b/src/domains/client/checkout/api/checkoutApi.js
@@ -1,10 +1,11 @@
 import { axiosInstance } from "@/common/api/apiInstacne";
 import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils";
 
-export async function reserveCheckout(cartItemIds = []) {
+export async function reserveCheckout(cartItemIds = [], idempotencyKey) {
     try {
         const response = await axiosInstance.post("/v1/cart/checkout/reservations", {
             cartItemIds,
+            idempotencyKey,
         });
         return unwrapApiResponseBody(response, "체크아웃 예약에 실패했습니다.");
     } catch (error) {

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -160,6 +160,7 @@ function CheckoutPage() {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState(null);
     const orderIdRef = useRef(null);
+    const idempotencyKeyRef = useRef(null);
 
     const directItem = useMemo(
         () =>
@@ -246,7 +247,13 @@ function CheckoutPage() {
         try {
             // Step 1: 재고 예약
             const cartItemIds = checkoutItems.map((item) => item.id);
-            const reservation = await reserveMutation.mutateAsync(cartItemIds);
+            if (!idempotencyKeyRef.current) {
+                idempotencyKeyRef.current = crypto.randomUUID();
+            }
+            const reservation = await reserveMutation.mutateAsync({
+                cartItemIds,
+                idempotencyKey: idempotencyKeyRef.current,
+            });
             const orderId = reservation?.orderId ?? `DM${Date.now()}`;
             orderIdRef.current = orderId;
 
@@ -280,6 +287,7 @@ function CheckoutPage() {
 
             // 토스가 successUrl로 리다이렉트하므로 여기까지 오지 않음
             orderIdRef.current = null;
+            idempotencyKeyRef.current = null;
         } catch (error) {
             // 토스 결제창에서 사용자가 닫기/취소한 경우
             if (error?.code === "USER_CANCEL" || error?.message?.includes("취소")) {
@@ -294,6 +302,7 @@ function CheckoutPage() {
                 cancelMutation.mutate(orderIdRef.current);
                 orderIdRef.current = null;
             }
+            idempotencyKeyRef.current = null;
         }
     };
 

--- a/src/domains/client/checkout/query/useCheckoutQueries.js
+++ b/src/domains/client/checkout/query/useCheckoutQueries.js
@@ -14,8 +14,8 @@ import {
 
 export function useReserveCheckout() {
     return useMutation({
-        mutationFn: async (cartItemIds) => {
-            const payload = await reserveCheckout(cartItemIds);
+        mutationFn: async ({ cartItemIds, idempotencyKey }) => {
+            const payload = await reserveCheckout(cartItemIds, idempotencyKey);
             return mapReservationPayload(payload);
         },
     });


### PR DESCRIPTION
## 개요

- `POST /v1/cart/checkout/reservations` 요청 바디에 `idempotencyKey` 필드가 없어 백엔드 `@NotBlank` 검증 실패 → `VALID-002: idempotencyKey: 공백일 수 없습니다` 오류 수정
- `CheckoutPage`에서 결제 버튼 클릭 시 `crypto.randomUUID()`로 UUID를 생성하여 `idempotencyKeyRef`에 저장
- 동일 세션 내 재시도 시 같은 키를 재사용하고, 성공/취소 후 초기화하여 중복 결제 방지

## 변경 파일

- `checkoutApi.js`: `reserveCheckout(cartItemIds, idempotencyKey)` — `idempotencyKey`를 요청 바디에 포함
- `useCheckoutQueries.js`: `mutationFn` 인자를 `{ cartItemIds, idempotencyKey }`로 변경
- `CheckoutPage.jsx`: `idempotencyKeyRef` 추가, 결제 시도마다 UUID 생성 및 전달

## 테스트

- [ ] 결제하기 버튼 클릭 시 `VALID-002` 오류 없이 체크아웃 예약 요청 성공 확인
- [ ] 네트워크 탭에서 요청 바디에 `idempotencyKey` UUID 포함 확인
- [ ] 결제 취소 후 재시도 시 새 UUID로 요청되는지 확인
