### PR TITLE
fix: add idempotencyKey UUID to checkout reservation API call

### DIFF
--- a/src/domains/client/checkout/api/checkoutApi.js
+++ b/src/domains/client/checkout/api/checkoutApi.js
@@ -1,10 +1,11 @@
 import { axiosInstance } from "@/common/api/apiInstacne";
 import { normalizeApiError, unwrapApiResponseBody } from "@/common/api/responseUtils";
 
-export async function reserveCheckout(cartItemIds = []) {
+export async function reserveCheckout(cartItemIds = [], idempotencyKey) {
     try {
         const response = await axiosInstance.post("/v1/cart/checkout/reservations", {
             cartItemIds,
+            idempotencyKey,
         });
         return unwrapApiResponseBody(response, "체크아웃 예약에 실패했습니다.");
     } catch (error) {

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -160,6 +160,7 @@ function CheckoutPage() {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState(null);
     const orderIdRef = useRef(null);
+    const idempotencyKeyRef = useRef(null);
 
     const directItem = useMemo(
         () =>
@@ -246,7 +247,13 @@ function CheckoutPage() {
         try {
             // Step 1: 재고 예약
             const cartItemIds = checkoutItems.map((item) => item.id);
-            const reservation = await reserveMutation.mutateAsync(cartItemIds);
+            if (!idempotencyKeyRef.current) {
+                idempotencyKeyRef.current = crypto.randomUUID();
+            }
+            const reservation = await reserveMutation.mutateAsync({
+                cartItemIds,
+                idempotencyKey: idempotencyKeyRef.current,
+            });
             const orderId = reservation?.orderId ?? `DM${Date.now()}`;
             orderIdRef.current = orderId;
 
@@ -280,6 +287,7 @@ function CheckoutPage() {
 
             // 토스가 successUrl로 리다이렉트하므로 여기까지 오지 않음
             orderIdRef.current = null;
+            idempotencyKeyRef.current = null;
         } catch (error) {
             // 토스 결제창에서 사용자가 닫기/취소한 경우
             if (error?.code === "USER_CANCEL" || error?.message?.includes("취소")) {
@@ -294,6 +302,7 @@ function CheckoutPage() {
                 cancelMutation.mutate(orderIdRef.current);
                 orderIdRef.current = null;
             }
+            idempotencyKeyRef.current = null;
         }
     };
 

--- a/src/domains/client/checkout/query/useCheckoutQueries.js
+++ b/src/domains/client/checkout/query/useCheckoutQueries.js
@@ -14,8 +14,8 @@ import {
 
 export function useReserveCheckout() {
     return useMutation({
-        mutationFn: async (cartItemIds) => {
-            const payload = await reserveCheckout(cartItemIds);
+        mutationFn: async ({ cartItemIds, idempotencyKey }) => {
+            const payload = await reserveCheckout(cartItemIds, idempotencyKey);
             return mapReservationPayload(payload);
         },
     });


### PR DESCRIPTION
Fixes VALID-002 error caused by missing idempotencyKey field in POST /v1/cart/checkout/reservations.
- reserveCheckout() now accepts and sends idempotencyKey in the request body
- CheckoutPage generates a crypto.randomUUID() per checkout attempt via idempotencyKeyRef
- Same key is reused on retry; key is cleared after success or cancellation

## 개요

### 관련 이슈
<!-- "Closes #이슈번호" 형식으로 작성하면 PR 머지 시 이슈가 자동 닫히고 Jira도 Done 전환됩니다 -->
- Closes #

### 작업 / 변경 내용
<!-- 무엇을 왜 변경했는지 간단히 -->
- 무엇을 왜 변경했는지 간다히
- 관련 테스트 작성 또는 확인
- 스키마/마이그레이션 변경 시 팀원 공유


### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [ ] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
<!-- 리뷰 시 중점적으로 봐주면 좋을 부분, 논의 사항 등 (선택) -->