### PR TITLE
fix: 배송지 폼 deliveryName → recipientName 변경 및 recipientPhone 필드 추가

### DIFF
--- a/src/domains/client/address/actions/addressSchema.js
+++ b/src/domains/client/address/actions/addressSchema.js
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
 export const addressSchema = z.object({
-    deliveryName: z.string().min(1, "수령인 이름을 입력해주세요.").max(20, "최대 20자까지 입력 가능합니다."),
+    recipientName: z.string().min(1, "수령인 이름을 입력해주세요.").max(20, "최대 20자까지 입력 가능합니다."),
+    recipientPhone: z
+        .string()
+        .min(1, "연락처를 입력해주세요.")
+        .regex(/^01[016789]-?\d{3,4}-?\d{4}$/, "올바른 휴대폰 번호를 입력해주세요."),
     zipcode: z.string().min(1, "우편번호를 입력해주세요.").max(10, "올바른 우편번호를 입력해주세요."),
     sido: z.string().min(1, "시/도를 입력해주세요."),
     sigungu: z.string().min(1, "시/군/구를 입력해주세요."),
@@ -12,7 +16,8 @@ export const addressSchema = z.object({
 });
 
 export const EMPTY_ADDRESS_FORM = {
-    deliveryName: "",
+    recipientName: "",
+    recipientPhone: "",
     zipcode: "",
     sido: "",
     sigungu: "",

--- a/src/domains/client/address/components/AddressCard.jsx
+++ b/src/domains/client/address/components/AddressCard.jsx
@@ -10,13 +10,14 @@ function AddressCard({ address, onEdit, onDelete, onSetDefault, isSettingDefault
             <CardHeader className="pb-2">
                 <CardTitle className="flex items-center gap-2 text-base">
                     <MapPin className="h-4 w-4 text-primary shrink-0" />
-                    <span className="truncate">{address.deliveryName}</span>
+                    <span className="truncate">{address.recipientName}</span>
                     {address.isDefault && (
                         <Badge className="rounded-full text-[11px] font-semibold shrink-0">기본</Badge>
                     )}
                 </CardTitle>
             </CardHeader>
             <CardContent className="space-y-1 text-sm text-muted-foreground">
+                {address.recipientPhone && <p>{address.recipientPhone}</p>}
                 <p>{address.fullAddress}</p>
                 <div className="flex flex-wrap gap-2 pt-2">
                     <Button

--- a/src/domains/client/address/components/AddressForm.jsx
+++ b/src/domains/client/address/components/AddressForm.jsx
@@ -8,7 +8,7 @@ import { useKakaoPostcode } from "@/domains/client/address/hook/useKakaoPostcode
 /**
  * AddressForm (Molecule)
  *
- * values: { deliveryName, zipcode, sido, sigungu, roadName, buildingNumber, buildingName, detailAddress }
+ * values: { recipientName, recipientPhone, zipcode, sido, sigungu, roadName, buildingNumber, buildingName, detailAddress }
  * errors: fieldErrors from Zod
  * onChange: (field, value) => void
  * onAddressSelect: (kakaoResult) => void  — 주소 검색 완료 시 여러 필드를 한번에 채움
@@ -25,18 +25,36 @@ function AddressForm({ values, errors = {}, onChange, onAddressSelect }) {
     return (
         <div className="space-y-4">
             <FormField
-                id="deliveryName"
+                id="recipientName"
                 label="수령인"
                 required
-                hint={errors.deliveryName?.[0]}
-                hintError={Boolean(errors.deliveryName)}
+                hint={errors.recipientName?.[0]}
+                hintError={Boolean(errors.recipientName)}
             >
                 <Input
-                    id="deliveryName"
-                    value={values.deliveryName}
-                    onChange={(e) => onChange("deliveryName", e.target.value)}
+                    id="recipientName"
+                    value={values.recipientName}
+                    onChange={(e) => onChange("recipientName", e.target.value)}
                     placeholder="홍길동"
                     maxLength={20}
+                    className="h-11 rounded-xl"
+                />
+            </FormField>
+
+            <FormField
+                id="recipientPhone"
+                label="연락처"
+                required
+                hint={errors.recipientPhone?.[0]}
+                hintError={Boolean(errors.recipientPhone)}
+            >
+                <Input
+                    id="recipientPhone"
+                    type="tel"
+                    value={values.recipientPhone}
+                    onChange={(e) => onChange("recipientPhone", e.target.value)}
+                    placeholder="010-1234-5678"
+                    maxLength={13}
                     className="h-11 rounded-xl"
                 />
             </FormField>

--- a/src/domains/client/address/components/AddressFormModal.jsx
+++ b/src/domains/client/address/components/AddressFormModal.jsx
@@ -9,10 +9,11 @@ import { useCreateAddress, useUpdateAddress } from "@/domains/client/address/hoo
 function getInitialValues(address) {
     if (!address) return { ...EMPTY_ADDRESS_FORM, fullAddress: "" };
     // GET /api/profile/addresses 응답(AddressResponse)은 granular 필드를 포함하지 않으므로
-    // 주소는 카카오 재검색으로 채우고, deliveryName만 유지합니다.
+    // 주소는 카카오 재검색으로 채우고, 수령인 정보만 유지합니다.
     return {
         ...EMPTY_ADDRESS_FORM,
-        deliveryName: address.deliveryName ?? "",
+        recipientName: address.recipientName ?? "",
+        recipientPhone: address.recipientPhone ?? "",
         fullAddress: address.fullAddress ?? "",
     };
 }

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -472,13 +472,13 @@ function CheckoutPage() {
                                     }`}
                                 >
                                     <p className="text-sm font-semibold">
-                                        {address.deliveryName}{" "}
+                                        {address.recipientName}{" "}
                                         {address.isDefault && (
                                             <span className="ml-1 text-xs opacity-80">기본 배송지</span>
                                         )}
                                     </p>
                                     <p className="mt-1 text-sm">
-                                        {address.recipientName} · {address.recipientPhone}
+                                        {address.recipientPhone}
                                     </p>
                                     <p className="mt-1 text-xs opacity-85">
                                         ({address.zipcode}) {address.fullAddress}


### PR DESCRIPTION
백엔드 AddressResponse에 recipientName/recipientPhone이 있으나 프론트엔드 폼에서 deliveryName으로 매핑하고 전화번호 필드가 없어
체크아웃 시 수령인 정보가 null로 전달되는 문제 수정

- addressSchema: deliveryName → recipientName, recipientPhone 추가
- AddressForm: 수령인 이름/연락처 입력 필드 UI 구현
- AddressFormModal: 수정 모드 초기값 매핑 변경
- AddressCard: 수령인 이름/연락처 표시
- CheckoutPage: 배송지 선택 UI deliveryName → recipientName 변경

## 개요

### 관련 이슈
<!-- "Closes #이슈번호" 형식으로 작성하면 PR 머지 시 이슈가 자동 닫히고 Jira도 Done 전환됩니다 -->
- Closes #

### 작업 / 변경 내용
<!-- 무엇을 왜 변경했는지 간단히 -->
- 무엇을 왜 변경했는지 간다히
- 관련 테스트 작성 또는 확인
- 스키마/마이그레이션 변경 시 팀원 공유


### 테스트 / 체크리스트
- [ ] 로컬에서 빌드 확인 (`./gradlew build`)
- [ ] 관련 테스트 작성 또는 확인
- [ ] 스키마/마이그레이션 변경 시 팀원 공유

### 참고사항
<!-- 리뷰 시 중점적으로 봐주면 좋을 부분, 논의 사항 등 (선택) -->