### PR TITLE
fix: 체크아웃 배송지 수령인 정보 입력 및 배송지 추가 기능

### DIFF
--- a/src/domains/client/address/actions/addressSchema.js
+++ b/src/domains/client/address/actions/addressSchema.js
@@ -1,7 +1,11 @@
 import { z } from "zod";
 
 export const addressSchema = z.object({
-    deliveryName: z.string().min(1, "수령인 이름을 입력해주세요.").max(20, "최대 20자까지 입력 가능합니다."),
+    recipientName: z.string().min(1, "수령인 이름을 입력해주세요.").max(20, "최대 20자까지 입력 가능합니다."),
+    recipientPhone: z
+        .string()
+        .min(1, "연락처를 입력해주세요.")
+        .regex(/^01[016789]-?\d{3,4}-?\d{4}$/, "올바른 휴대폰 번호를 입력해주세요."),
     zipcode: z.string().min(1, "우편번호를 입력해주세요.").max(10, "올바른 우편번호를 입력해주세요."),
     sido: z.string().min(1, "시/도를 입력해주세요."),
     sigungu: z.string().min(1, "시/군/구를 입력해주세요."),
@@ -12,7 +16,8 @@ export const addressSchema = z.object({
 });
 
 export const EMPTY_ADDRESS_FORM = {
-    deliveryName: "",
+    recipientName: "",
+    recipientPhone: "",
     zipcode: "",
     sido: "",
     sigungu: "",

--- a/src/domains/client/address/components/AddressCard.jsx
+++ b/src/domains/client/address/components/AddressCard.jsx
@@ -10,13 +10,14 @@ function AddressCard({ address, onEdit, onDelete, onSetDefault, isSettingDefault
             <CardHeader className="pb-2">
                 <CardTitle className="flex items-center gap-2 text-base">
                     <MapPin className="h-4 w-4 text-primary shrink-0" />
-                    <span className="truncate">{address.deliveryName}</span>
+                    <span className="truncate">{address.recipientName}</span>
                     {address.isDefault && (
                         <Badge className="rounded-full text-[11px] font-semibold shrink-0">기본</Badge>
                     )}
                 </CardTitle>
             </CardHeader>
             <CardContent className="space-y-1 text-sm text-muted-foreground">
+                {address.recipientPhone && <p>{address.recipientPhone}</p>}
                 <p>{address.fullAddress}</p>
                 <div className="flex flex-wrap gap-2 pt-2">
                     <Button

--- a/src/domains/client/address/components/AddressForm.jsx
+++ b/src/domains/client/address/components/AddressForm.jsx
@@ -8,7 +8,7 @@ import { useKakaoPostcode } from "@/domains/client/address/hook/useKakaoPostcode
 /**
  * AddressForm (Molecule)
  *
- * values: { deliveryName, zipcode, sido, sigungu, roadName, buildingNumber, buildingName, detailAddress }
+ * values: { recipientName, recipientPhone, zipcode, sido, sigungu, roadName, buildingNumber, buildingName, detailAddress }
  * errors: fieldErrors from Zod
  * onChange: (field, value) => void
  * onAddressSelect: (kakaoResult) => void  — 주소 검색 완료 시 여러 필드를 한번에 채움
@@ -25,18 +25,36 @@ function AddressForm({ values, errors = {}, onChange, onAddressSelect }) {
     return (
         <div className="space-y-4">
             <FormField
-                id="deliveryName"
+                id="recipientName"
                 label="수령인"
                 required
-                hint={errors.deliveryName?.[0]}
-                hintError={Boolean(errors.deliveryName)}
+                hint={errors.recipientName?.[0]}
+                hintError={Boolean(errors.recipientName)}
             >
                 <Input
-                    id="deliveryName"
-                    value={values.deliveryName}
-                    onChange={(e) => onChange("deliveryName", e.target.value)}
+                    id="recipientName"
+                    value={values.recipientName}
+                    onChange={(e) => onChange("recipientName", e.target.value)}
                     placeholder="홍길동"
                     maxLength={20}
+                    className="h-11 rounded-xl"
+                />
+            </FormField>
+
+            <FormField
+                id="recipientPhone"
+                label="연락처"
+                required
+                hint={errors.recipientPhone?.[0]}
+                hintError={Boolean(errors.recipientPhone)}
+            >
+                <Input
+                    id="recipientPhone"
+                    type="tel"
+                    value={values.recipientPhone}
+                    onChange={(e) => onChange("recipientPhone", e.target.value)}
+                    placeholder="010-1234-5678"
+                    maxLength={13}
                     className="h-11 rounded-xl"
                 />
             </FormField>

--- a/src/domains/client/address/components/AddressFormModal.jsx
+++ b/src/domains/client/address/components/AddressFormModal.jsx
@@ -9,10 +9,11 @@ import { useCreateAddress, useUpdateAddress } from "@/domains/client/address/hoo
 function getInitialValues(address) {
     if (!address) return { ...EMPTY_ADDRESS_FORM, fullAddress: "" };
     // GET /api/profile/addresses 응답(AddressResponse)은 granular 필드를 포함하지 않으므로
-    // 주소는 카카오 재검색으로 채우고, deliveryName만 유지합니다.
+    // 주소는 카카오 재검색으로 채우고, 수령인 정보만 유지합니다.
     return {
         ...EMPTY_ADDRESS_FORM,
-        deliveryName: address.deliveryName ?? "",
+        recipientName: address.recipientName ?? "",
+        recipientPhone: address.recipientPhone ?? "",
         fullAddress: address.fullAddress ?? "",
     };
 }

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -5,7 +5,9 @@ import {
     CreditCard,
     Loader2,
     MapPin,
+    Plus,
     RefreshCw,
+    Search,
     ShieldCheck,
     TicketPercent,
 } from "lucide-react";
@@ -20,6 +22,8 @@ import { useAuthStore } from "@/common/store/useAuthStore.js";
 import { formatPrice, parsePriceText } from "@/domains/client/common/utils/format.js";
 import { coupons } from "@/domains/client/order/mock/orderData.js";
 import { useAddresses } from "@/domains/client/address/query/useAddressQueries";
+import { useCreateAddress, useSetDefaultAddress } from "@/domains/client/address/hook/useAddressQuery";
+import { useKakaoPostcode } from "@/domains/client/address/hook/useKakaoPostcode";
 import { findStoreProduct } from "@/domains/client/store/mock/storeData.js";
 import {
     useReserveCheckout,
@@ -159,6 +163,11 @@ function CheckoutPage() {
     // 배송지 조회
     const { data: addresses = [] } = useAddresses();
 
+    // 배송지 API mutations
+    const createAddressMutation = useCreateAddress();
+    const setDefaultAddressMutation = useSetDefaultAddress();
+    const { open: openPostcode } = useKakaoPostcode();
+
     // 체크아웃 API mutations
     const reserveMutation = useReserveCheckout();
     const submitMutation = useSubmitCheckout();
@@ -235,6 +244,65 @@ function CheckoutPage() {
     }, [addresses, selectedAddressId]);
     const [recipientName, setRecipientName] = useState("");
     const [recipientPhone, setRecipientPhone] = useState("");
+
+    // 배송지 추가 폼 상태
+    const [showAddressForm, setShowAddressForm] = useState(false);
+    const [newAddress, setNewAddress] = useState({ zipcode: "", fullAddress: "", detailAddress: "" });
+    const [setAsDefault, setSetAsDefault] = useState(false);
+    const [addressSaveError, setAddressSaveError] = useState(null);
+
+    const handleAddressSearch = () => {
+        openPostcode((result) => {
+            setNewAddress((prev) => ({
+                ...prev,
+                zipcode: result.zipcode,
+                fullAddress: result.fullAddress,
+                sido: result.sido,
+                sigungu: result.sigungu,
+                roadName: result.roadName,
+                buildingNumber: result.buildingNumber,
+                buildingName: result.buildingName,
+            }));
+        });
+    };
+
+    const handleSaveNewAddress = async () => {
+        if (!recipientName.trim() || !recipientPhone.trim() || !newAddress.zipcode) return;
+
+        setAddressSaveError(null);
+        try {
+            const payload = {
+                recipientName: recipientName.trim(),
+                recipientPhone: recipientPhone.trim(),
+                zipcode: newAddress.zipcode,
+                sido: newAddress.sido,
+                sigungu: newAddress.sigungu,
+                roadName: newAddress.roadName,
+                buildingNumber: newAddress.buildingNumber,
+                buildingName: newAddress.buildingName ?? "",
+                detailAddress: newAddress.detailAddress ?? "",
+                sortOrder: 0,
+            };
+
+            const created = await createAddressMutation.mutateAsync(payload);
+            const newId = created?.id ?? created?.addressId;
+
+            if (setAsDefault && newId) {
+                await setDefaultAddressMutation.mutateAsync(newId);
+            }
+
+            if (newId) {
+                setSelectedAddressId(newId);
+            }
+
+            setShowAddressForm(false);
+            setNewAddress({ zipcode: "", fullAddress: "", detailAddress: "" });
+            setSetAsDefault(false);
+        } catch (error) {
+            setAddressSaveError(error?.message ?? "배송지 저장에 실패했습니다.");
+        }
+    };
+
     const [selectedCouponId, setSelectedCouponId] = useState("");
     const [deliveryMessage, setDeliveryMessage] = useState("문 앞에 두고 벨 눌러주세요.");
     const [usedPoint, setUsedPoint] = useState(3000);
@@ -270,7 +338,7 @@ function CheckoutPage() {
     const selectedAddress =
         addresses.find((address) => address.id === selectedAddressId) ?? addresses[0];
     const hasRecipientInfo = Boolean(recipientName.trim() && recipientPhone.trim());
-    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting && hasRecipientInfo;
+    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting && hasRecipientInfo && !showAddressForm && Boolean(selectedAddress);
 
     // 체크아웃: reservations → submit → 토스 결제창
     const handleSubmitCheckout = async () => {
@@ -460,11 +528,8 @@ function CheckoutPage() {
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3">
-                        {addresses.length === 0 ? (
-                            <p className="rounded-2xl border border-border bg-muted p-4 text-sm text-muted-foreground">
-                                등록된 배송지가 없습니다. 배송지 관리 페이지에서 배송지를 추가해 주세요.
-                            </p>
-                        ) : (
+                        {/* 기존 배송지 목록 */}
+                        {addresses.length > 0 &&
                             addresses.map((address) => (
                                 <button
                                     key={address.id}
@@ -473,9 +538,10 @@ function CheckoutPage() {
                                         setSelectedAddressId(address.id);
                                         setRecipientName(address.recipientName ?? "");
                                         setRecipientPhone(address.recipientPhone ?? "");
+                                        setShowAddressForm(false);
                                     }}
                                     className={`w-full rounded-2xl border p-4 text-left transition-colors ${
-                                        selectedAddressId === address.id
+                                        selectedAddressId === address.id && !showAddressForm
                                             ? "border-primary bg-primary text-primary-foreground"
                                             : "border-border bg-card text-foreground hover:border-primary"
                                     }`}
@@ -494,28 +560,151 @@ function CheckoutPage() {
                                     </p>
                                 </button>
                             ))
+                        }
+
+                        {/* 새 배송지 추가 버튼 / 폼 */}
+                        {!showAddressForm ? (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                className="w-full rounded-2xl h-12"
+                                onClick={() => {
+                                    setShowAddressForm(true);
+                                    setSelectedAddressId("");
+                                    setRecipientName("");
+                                    setRecipientPhone("");
+                                    setNewAddress({ zipcode: "", fullAddress: "", detailAddress: "" });
+                                }}
+                            >
+                                <Plus className="h-4 w-4" />
+                                새 배송지 추가
+                            </Button>
+                        ) : (
+                            <div className="rounded-2xl border border-primary p-4 space-y-3">
+                                <p className="text-sm font-semibold">새 배송지 추가</p>
+
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                    <Input
+                                        value={recipientName}
+                                        onChange={(e) => setRecipientName(e.target.value)}
+                                        placeholder="수령인 이름"
+                                        maxLength={20}
+                                    />
+                                    <Input
+                                        type="tel"
+                                        value={recipientPhone}
+                                        onChange={(e) => setRecipientPhone(e.target.value)}
+                                        placeholder="연락처 (010-1234-5678)"
+                                        maxLength={13}
+                                    />
+                                </div>
+
+                                <div className="flex gap-2">
+                                    <Input
+                                        value={newAddress.zipcode}
+                                        readOnly
+                                        placeholder="우편번호"
+                                        className="w-32 bg-muted cursor-default"
+                                    />
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex-1"
+                                        onClick={handleAddressSearch}
+                                    >
+                                        <Search className="h-4 w-4" />
+                                        주소 검색
+                                    </Button>
+                                </div>
+
+                                {newAddress.fullAddress && (
+                                    <Input
+                                        value={newAddress.fullAddress}
+                                        readOnly
+                                        className="bg-muted cursor-default"
+                                    />
+                                )}
+
+                                <Input
+                                    value={newAddress.detailAddress}
+                                    onChange={(e) =>
+                                        setNewAddress((prev) => ({ ...prev, detailAddress: e.target.value }))
+                                    }
+                                    placeholder="상세주소 (동·호수, 층 등)"
+                                    disabled={!newAddress.zipcode}
+                                />
+
+                                <label className="flex items-center gap-2 text-sm cursor-pointer">
+                                    <input
+                                        type="checkbox"
+                                        checked={setAsDefault}
+                                        onChange={(e) => setSetAsDefault(e.target.checked)}
+                                        className="h-4 w-4 rounded border-border"
+                                    />
+                                    기본 배송지로 설정
+                                </label>
+
+                                {addressSaveError && (
+                                    <p className="text-xs text-destructive">{addressSaveError}</p>
+                                )}
+
+                                <div className="flex gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        className="flex-1 rounded-full"
+                                        onClick={() => {
+                                            setShowAddressForm(false);
+                                            if (addresses.length > 0) {
+                                                const fallback = addresses.find((a) => a.isDefault) ?? addresses[0];
+                                                setSelectedAddressId(fallback.id);
+                                                setRecipientName(fallback.recipientName ?? "");
+                                                setRecipientPhone(fallback.recipientPhone ?? "");
+                                            }
+                                        }}
+                                    >
+                                        취소
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        className="flex-[2] rounded-full"
+                                        disabled={
+                                            !recipientName.trim() ||
+                                            !recipientPhone.trim() ||
+                                            !newAddress.zipcode ||
+                                            createAddressMutation.isPending
+                                        }
+                                        onClick={handleSaveNewAddress}
+                                    >
+                                        {createAddressMutation.isPending ? "저장 중..." : "배송지 저장"}
+                                    </Button>
+                                </div>
+                            </div>
                         )}
 
-                        <div className="space-y-3 pt-1">
-                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                수령인 정보
-                            </p>
-                            <div className="grid gap-3 sm:grid-cols-2">
-                                <Input
-                                    value={recipientName}
-                                    onChange={(e) => setRecipientName(e.target.value)}
-                                    placeholder="수령인 이름"
-                                    maxLength={20}
-                                />
-                                <Input
-                                    type="tel"
-                                    value={recipientPhone}
-                                    onChange={(e) => setRecipientPhone(e.target.value)}
-                                    placeholder="연락처 (010-1234-5678)"
-                                    maxLength={13}
-                                />
+                        {/* 수령인 정보 (기존 배송지 선택 시) */}
+                        {!showAddressForm && selectedAddress && (
+                            <div className="space-y-3 pt-1">
+                                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                    수령인 정보
+                                </p>
+                                <div className="grid gap-3 sm:grid-cols-2">
+                                    <Input
+                                        value={recipientName}
+                                        onChange={(e) => setRecipientName(e.target.value)}
+                                        placeholder="수령인 이름"
+                                        maxLength={20}
+                                    />
+                                    <Input
+                                        type="tel"
+                                        value={recipientPhone}
+                                        onChange={(e) => setRecipientPhone(e.target.value)}
+                                        placeholder="연락처 (010-1234-5678)"
+                                        maxLength={13}
+                                    />
+                                </div>
                             </div>
-                        </div>
+                        )}
 
                         <div className="space-y-2 pt-1">
                             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -472,13 +472,13 @@ function CheckoutPage() {
                                     }`}
                                 >
                                     <p className="text-sm font-semibold">
-                                        {address.deliveryName}{" "}
+                                        {address.recipientName}{" "}
                                         {address.isDefault && (
                                             <span className="ml-1 text-xs opacity-80">기본 배송지</span>
                                         )}
                                     </p>
                                     <p className="mt-1 text-sm">
-                                        {address.recipientName} · {address.recipientPhone}
+                                        {address.recipientPhone}
                                     </p>
                                     <p className="mt-1 text-xs opacity-85">
                                         ({address.zipcode}) {address.fullAddress}

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -229,8 +229,12 @@ function CheckoutPage() {
         if (addresses.length > 0 && !selectedAddressId) {
             const defaultAddress = addresses.find((a) => a.isDefault) ?? addresses[0];
             setSelectedAddressId(defaultAddress.id);
+            setRecipientName(defaultAddress.recipientName ?? "");
+            setRecipientPhone(defaultAddress.recipientPhone ?? "");
         }
     }, [addresses, selectedAddressId]);
+    const [recipientName, setRecipientName] = useState("");
+    const [recipientPhone, setRecipientPhone] = useState("");
     const [selectedCouponId, setSelectedCouponId] = useState("");
     const [deliveryMessage, setDeliveryMessage] = useState("문 앞에 두고 벨 눌러주세요.");
     const [usedPoint, setUsedPoint] = useState(3000);
@@ -265,7 +269,7 @@ function CheckoutPage() {
 
     const selectedAddress =
         addresses.find((address) => address.id === selectedAddressId) ?? addresses[0];
-    const hasRecipientInfo = Boolean(selectedAddress?.recipientName && selectedAddress?.recipientPhone);
+    const hasRecipientInfo = Boolean(recipientName.trim() && recipientPhone.trim());
     const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting && hasRecipientInfo;
 
     // 체크아웃: reservations → submit → 토스 결제창
@@ -296,8 +300,8 @@ function CheckoutPage() {
             // Step 2: 주문 확정 (배송정보 제출) → PENDING_PAYMENT 상태
             await submitMutation.mutateAsync({
                 orderId,
-                recipientName: selectedAddress.recipientName,
-                recipientPhone: selectedAddress.recipientPhone,
+                recipientName: recipientName.trim(),
+                recipientPhone: recipientPhone.trim(),
                 deliveryAddressId: selectedAddress.id,
                 deliveryMemo: deliveryMessage,
             });
@@ -465,7 +469,11 @@ function CheckoutPage() {
                                 <button
                                     key={address.id}
                                     type="button"
-                                    onClick={() => setSelectedAddressId(address.id)}
+                                    onClick={() => {
+                                        setSelectedAddressId(address.id);
+                                        setRecipientName(address.recipientName ?? "");
+                                        setRecipientPhone(address.recipientPhone ?? "");
+                                    }}
                                     className={`w-full rounded-2xl border p-4 text-left transition-colors ${
                                         selectedAddressId === address.id
                                             ? "border-primary bg-primary text-primary-foreground"
@@ -488,18 +496,26 @@ function CheckoutPage() {
                             ))
                         )}
 
-                        {selectedAddress && !hasRecipientInfo && (
-                            <Alert variant="destructive">
-                                <AlertCircle className="h-4 w-4" />
-                                <AlertDescription>
-                                    선택한 배송지에 수령인 이름 또는 연락처가 없습니다.{" "}
-                                    <Link to="/my/addresses" className="underline font-semibold">
-                                        배송지 관리
-                                    </Link>
-                                    에서 수령인 정보를 입력해 주세요.
-                                </AlertDescription>
-                            </Alert>
-                        )}
+                        <div className="space-y-3 pt-1">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                수령인 정보
+                            </p>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <Input
+                                    value={recipientName}
+                                    onChange={(e) => setRecipientName(e.target.value)}
+                                    placeholder="수령인 이름"
+                                    maxLength={20}
+                                />
+                                <Input
+                                    type="tel"
+                                    value={recipientPhone}
+                                    onChange={(e) => setRecipientPhone(e.target.value)}
+                                    placeholder="연락처 (010-1234-5678)"
+                                    maxLength={13}
+                                />
+                            </div>
+                        </div>
 
                         <div className="space-y-2 pt-1">
                             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -265,11 +265,12 @@ function CheckoutPage() {
 
     const selectedAddress =
         addresses.find((address) => address.id === selectedAddressId) ?? addresses[0];
-    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting;
+    const hasRecipientInfo = Boolean(selectedAddress?.recipientName && selectedAddress?.recipientPhone);
+    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting && hasRecipientInfo;
 
     // 체크아웃: reservations → submit → 토스 결제창
     const handleSubmitCheckout = async () => {
-        if (!isCheckoutReady) return;
+        if (!isCheckoutReady || !selectedAddress) return;
 
         setIsSubmitting(true);
         setSubmitError(null);
@@ -485,6 +486,19 @@ function CheckoutPage() {
                                     </p>
                                 </button>
                             ))
+                        )}
+
+                        {selectedAddress && !hasRecipientInfo && (
+                            <Alert variant="destructive">
+                                <AlertCircle className="h-4 w-4" />
+                                <AlertDescription>
+                                    선택한 배송지에 수령인 이름 또는 연락처가 없습니다.{" "}
+                                    <Link to="/my/addresses" className="underline font-semibold">
+                                        배송지 관리
+                                    </Link>
+                                    에서 수령인 정보를 입력해 주세요.
+                                </AlertDescription>
+                            </Alert>
                         )}
 
                         <div className="space-y-2 pt-1">


### PR DESCRIPTION
## Summary
- 배송지 폼 `deliveryName` → `recipientName` 변경, `recipientPhone` 필드 추가 (백엔드 DTO 매칭)
- 체크아웃 페이지에서 수령인 이름/연락처 직접 입력 가능
- 체크아웃 페이지에서 새 배송지 추가 기능 (카카오 주소검색, 기본 배송지 설정)
- 저장한 배송지는 마이페이지 배송지 관리에도 반영
- `selectedAddress` null 가드 추가로 크래시 방지

## Test plan
- [ ] 체크아웃 페이지에서 기존 배송지 선택 시 수령인 정보 자동 채움 확인
- [ ] 체크아웃 페이지에서 새 배송지 추가 → 저장 → 자동 선택 확인
- [ ] 기본 배송지 설정 체크 후 저장 → 마이페이지 반영 확인
- [ ] 수령인 정보 미입력 시 결제 버튼 비활성화 확인
- [ ] 배송지 관리 페이지에서 수령인/연락처 입력 폼 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)