### PR TITLE
fix: 주문완료 페이지 상품목록 매핑 수정

### DIFF
--- a/src/domains/client/order/lib/orderMappers.js
+++ b/src/domains/client/order/lib/orderMappers.js
@@ -34,13 +34,13 @@ export function canRefundOrder(status) {
 function mapOrderItem(raw) {
     return {
         id: toText(raw.id ?? raw.itemId ?? raw.orderItemId),
-        name: toText(raw.name ?? raw.productName ?? raw.itemName),
-        option: toText(raw.option ?? raw.optionName),
+        name: toText(raw.name ?? raw.productName ?? raw.itemName ?? raw.titleSnap ?? raw.title),
+        option: toText(raw.option ?? raw.optionName ?? raw.itemTypeSnap),
         thumbnail: toText(raw.thumbnail ?? raw.thumbnailUrl ?? raw.imageUrl),
-        storeName: toText(raw.storeName),
+        storeName: toText(raw.storeName ?? raw.storeNameSnap),
         storeId: toText(raw.storeId),
         quantity: toNumber(raw.quantity, 1),
-        unitPrice: toNumber(raw.unitPrice ?? raw.price),
+        unitPrice: toNumber(raw.unitPrice ?? raw.price ?? raw.priceSnap),
     };
 }
 
@@ -107,7 +107,7 @@ export function mapOrderDetailPayload(raw) {
         orderedAt: toText(raw.orderedAt ?? raw.createdAt ?? raw.orderDate),
         paymentMethod: toText(raw.paymentMethod, "토스페이먼츠"),
         items: Array.isArray(raw.items ?? raw.orderItems) ? (raw.items ?? raw.orderItems).map(mapOrderItem) : [],
-        shipping: mapShipping(raw.shipping ?? raw.shippingInfo ?? raw.deliveryInfo),
+        shipping: mapShipping(raw.shipping ?? raw.shipment ?? raw.shippingInfo ?? raw.deliveryInfo),
         subtotal,
         subtotalText: formatPrice(subtotal),
         discountAmount,


### PR DESCRIPTION
## Summary
- 백엔드 `OrderDetailResponse`가 반환하는 `titleSnap`, `storeNameSnap`, `itemTypeSnap`, `priceSnap` 필드를 프론트엔드 `mapOrderItem`에서 인식하도록 매핑 추가
- `shipment` 필드명 매핑 추가 (백엔드 응답 필드명과 불일치 수정)
- 주문완료 페이지에서 주문 상품 목록이 표시되지 않던 문제 해결

## Test plan
- [ ] 결제 완료 후 주문완료 페이지에서 주문 상품 목록이 정상 표시되는지 확인
- [ ] 상품명, 스토어명, 수량, 가격이 올바르게 매핑되는지 확인
- [ ] 주문 상세 페이지(`/my/orders/{orderId}`)에서도 동일하게 정상 표시되는지 확인

https://claude.ai/code/session_01TLQ2fbwXGA2vAuit2itqde