### PR TITLE
fix: 토스페이먼츠 위젯 → 기존 결제창 방식으로 되돌림

### DIFF
--- a/src/domains/client/checkout/page/CheckoutPage.jsx
+++ b/src/domains/client/checkout/page/CheckoutPage.jsx
@@ -169,8 +169,6 @@ function CheckoutPage() {
     const orderIdRef = useRef(null);
     const orderCreatedRef = useRef(false);
     const paymentRedirectingRef = useRef(false);
-    const widgetsRef = useRef(null);
-    const [widgetsReady, setWidgetsReady] = useState(false);
     const [cartReservation, setCartReservation] = useState(() => {
         if (directMode || hotDealMode) {
             return null;
@@ -354,49 +352,7 @@ function CheckoutPage() {
     const selectedAddress =
         addresses.find((address) => address.id === selectedAddressId) ?? addresses[0];
     const hasRecipientInfo = Boolean(recipientName.trim() && recipientPhone.trim());
-    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting && hasRecipientInfo && !showAddressForm && Boolean(selectedAddress) && orderAgreed && widgetsReady;
-
-    // 토스페이먼츠 위젯 초기화
-    useEffect(() => {
-        if (checkoutItems.length === 0 || finalAmount <= 0) return;
-
-        let cancelled = false;
-        (async () => {
-            try {
-                const tossPayments = await loadTossPayments(TOSS_CLIENT_KEY);
-                const widgets = tossPayments.widgets({ customerKey: tossCustomerKey });
-                await widgets.setAmount({ currency: "KRW", value: finalAmount });
-
-                if (cancelled) return;
-                widgetsRef.current = widgets;
-
-                await widgets.renderPaymentMethods({
-                    selector: "#toss-payment-methods",
-                    variantKey: "DEFAULT",
-                });
-                await widgets.renderAgreement({
-                    selector: "#toss-agreement",
-                    variantKey: "AGREEMENT",
-                });
-
-                if (!cancelled) setWidgetsReady(true);
-            } catch (err) {
-                if (!cancelled) {
-                    console.error("토스페이먼츠 위젯 초기화 실패:", err);
-                }
-            }
-        })();
-
-        return () => { cancelled = true; };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [checkoutItems.length > 0, tossCustomerKey]);
-
-    // 금액 변경 시 위젯 업데이트
-    useEffect(() => {
-        if (widgetsRef.current && finalAmount > 0) {
-            widgetsRef.current.setAmount({ currency: "KRW", value: finalAmount });
-        }
-    }, [finalAmount]);
+    const isCheckoutReady = checkoutItems.length > 0 && !isSubmitting && hasRecipientInfo && !showAddressForm && Boolean(selectedAddress) && orderAgreed;
 
     // 체크아웃: reservations → submit → 토스 결제창
     const handleSubmitCheckout = async () => {
@@ -451,18 +407,22 @@ function CheckoutPage() {
                 });
             }
 
-            // Step 3: 토스페이먼츠 위젯 결제 요청
+            // Step 3: 토스페이먼츠 결제창 호출
+            const tossPayments = await loadTossPayments(TOSS_CLIENT_KEY);
+            const payment = tossPayments.payment({ customerKey: tossCustomerKey });
+
             const orderName =
                 checkoutItems.length === 1
                     ? checkoutItems[0].name
                     : `${checkoutItems[0].name} 외 ${checkoutItems.length - 1}건`;
 
             paymentRedirectingRef.current = true;
-            await widgetsRef.current.requestPayment({
+            await payment.requestPayment({
+                method: "CARD",
+                amount: { currency: "KRW", value: finalAmount },
                 orderId,
                 orderName,
                 customerName: selectedAddress?.recipientName ?? "",
-                customerEmail: user?.email ?? "",
                 successUrl: `${window.location.origin}/order/complete?orderId=${orderId}&amount=${finalAmount}&mode=${hotDealMode ? "hotdeal" : (directMode ? "direct" : "cart")}`,
                 failUrl: `${window.location.origin}/order/fail?orderId=${orderId}&mode=${hotDealMode ? "hotdeal" : (directMode ? "direct" : "cart")}`,
             });
@@ -831,7 +791,7 @@ function CheckoutPage() {
                     </CardContent>
                 </Card>
 
-                {/* 결제 수단 — 토스페이먼츠 위젯 */}
+                {/* 결제 수단 — 토스페이먼츠 */}
                 <Card>
                     <CardHeader className="pb-3">
                         <CardTitle className="flex items-center gap-2 text-base">
@@ -840,8 +800,13 @@ function CheckoutPage() {
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-3">
-                        <div id="toss-payment-methods" className="min-h-[200px]" />
-                        <div id="toss-agreement" />
+                        <div className="rounded-2xl border border-primary/20 bg-primary/5 p-4 text-sm text-foreground">
+                            <p className="font-semibold">토스페이먼츠</p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                                결제하기 버튼을 누르면 토스페이먼츠 결제창이 열립니다.
+                                카드, 계좌이체, 간편결제(토스페이·네이버페이·카카오페이)를 선택할 수 있습니다.
+                            </p>
+                        </div>
                     </CardContent>
                 </Card>
             </div>


### PR DESCRIPTION
## Summary
- 토스페이먼츠 위젯 방식(`tossPayments.widgets()`)을 기존 `payment.requestPayment()` 방식으로 되돌림
- 현재 사용 중인 클라이언트 키(`test_ck_`)가 API 개별 연동 키라서 위젯(`test_gck_` 필요)을 지원하지 않음
- 위젯 관련 state/ref/useEffect 제거, 정적 결제수단 안내 UI 복원

## Test plan
- [ ] 체크아웃 페이지에서 결제하기 버튼 클릭 시 토스페이먼츠 결제창이 정상 열리는지 확인
- [ ] 결제 완료 후 successUrl로 정상 리다이렉트되는지 확인
- [ ] 위젯 초기화 에러가 더 이상 발생하지 않는지 확인

https://claude.ai/code/session_01TLQ2fbwXGA2vAuit2itqde