### PR TITLE
fix: 주문 상세/완료 페이지 빈 상품명·썸네일 fallback 처리

### DIFF
--- a/src/domains/client/order/page/OrderCompletePage.jsx
+++ b/src/domains/client/order/page/OrderCompletePage.jsx
@@ -142,10 +142,10 @@ function OrderCompletePage() {
                                             )}
                                             <div className="min-w-0 flex-1">
                                                 <p className="line-clamp-1 text-sm font-semibold text-foreground">
-                                                    {item.name}
+                                                    {item.name || `상품 #${item.id}`}
                                                 </p>
                                                 <p className="text-xs text-muted-foreground">
-                                                    {item.option} · x{item.quantity}
+                                                    {item.option ? `${item.option} · ` : ""}x{item.quantity}
                                                 </p>
                                             </div>
                                             <p className="text-sm font-semibold text-foreground">

--- a/src/domains/client/order/page/OrderDetailPage.jsx
+++ b/src/domains/client/order/page/OrderDetailPage.jsx
@@ -83,33 +83,47 @@ function OrderDetailPage() {
                             <CardTitle className="text-base">주문 상품</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3">
-                            {order.items.map((item) => (
-                                <div
-                                    key={item.id}
-                                    className="flex gap-3 rounded-xl border border-border bg-muted p-3"
-                                >
-                                    <img
-                                        src={item.thumbnail}
-                                        alt={item.name}
-                                        className="h-16 w-16 rounded-lg object-cover"
-                                    />
-                                    <div className="min-w-0 flex-1">
-                                        <p className="text-xs text-muted-foreground">{item.storeName}</p>
-                                        <p className="line-clamp-1 text-sm font-semibold text-foreground">
-                                            {item.name}
-                                        </p>
-                                        <p className="line-clamp-1 text-xs text-muted-foreground">
-                                            {item.option}
-                                        </p>
+                            {order.items.length > 0 ? (
+                                order.items.map((item) => (
+                                    <div
+                                        key={item.id}
+                                        className="flex gap-3 rounded-xl border border-border bg-muted p-3"
+                                    >
+                                        {item.thumbnail ? (
+                                            <img
+                                                src={item.thumbnail}
+                                                alt={item.name}
+                                                className="h-16 w-16 rounded-lg object-cover"
+                                            />
+                                        ) : (
+                                            <div className="grid h-16 w-16 place-items-center rounded-lg bg-card text-xs text-muted-foreground">
+                                                이미지 없음
+                                            </div>
+                                        )}
+                                        <div className="min-w-0 flex-1">
+                                            <p className="text-xs text-muted-foreground">{item.storeName || ""}</p>
+                                            <p className="line-clamp-1 text-sm font-semibold text-foreground">
+                                                {item.name || `상품 #${item.id}`}
+                                            </p>
+                                            {item.option && (
+                                                <p className="line-clamp-1 text-xs text-muted-foreground">
+                                                    {item.option}
+                                                </p>
+                                            )}
+                                        </div>
+                                        <div className="text-right">
+                                            <p className="text-xs text-muted-foreground">x {item.quantity}</p>
+                                            <p className="text-sm font-semibold text-foreground">
+                                                {formatPrice(item.unitPrice * item.quantity)}
+                                            </p>
+                                        </div>
                                     </div>
-                                    <div className="text-right">
-                                        <p className="text-xs text-muted-foreground">x {item.quantity}</p>
-                                        <p className="text-sm font-semibold text-foreground">
-                                            {formatPrice(item.unitPrice * item.quantity)}
-                                        </p>
-                                    </div>
-                                </div>
-                            ))}
+                                ))
+                            ) : (
+                                <p className="rounded-xl border border-border bg-muted p-3 text-xs text-muted-foreground">
+                                    주문 상품 정보를 불러올 수 없습니다.
+                                </p>
+                            )}
                         </CardContent>
                     </Card>
 


### PR DESCRIPTION
## Summary
- 주문 상세/완료 페이지에서 상품 썸네일이 없을 때 깨진 이미지 대신 "이미지 없음" 플레이스홀더 표시
- 상품명이 비어있을 때 `상품 #ID` 형태로 fallback 표시
- option 값이 비어있을 때 불필요한 구분자(·) 제거
- 주문 상품이 0건일 때 안내 메시지 표시

## Test plan
- [ ] 주문 상세 페이지에서 썸네일 없는 상품이 "이미지 없음" 플레이스홀더로 표시되는지 확인
- [ ] 상품명이 비어있을 때 "상품 #ID" 형태로 표시되는지 확인
- [ ] 주문 완료 페이지에서도 동일하게 표시되는지 확인

https://claude.ai/code/session_01TLQ2fbwXGA2vAuit2itqde